### PR TITLE
Save score and show the current mastered ratio

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     sourceType: 'module',
     extraFileExtensions: ['.vue'],
   },
-  plugins: ['vue', '@typescript-eslint'],
+  plugins: ['vue', '@typescript-eslint', 'simple-import-sort'],
   rules: {
     'vue/multi-word-component-names': [
       'error',
@@ -24,5 +24,7 @@ module.exports = {
         ignores: ['Header', 'Footer'],
       },
     ],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
   },
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "autoprefixer": "^10.4.2",
     "eslint": "^8.10.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-vue": "^8.5.0",
     "happy-dom": "^2.45.0",
     "postcss": "^8.4.7",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
+import chromeShortcutsJson from '@/assets/chrome.json'
+import Footer from '@/components/Footer.vue'
+import Header from '@/components/Header.vue'
 import GameView from '@/views/GameView.vue'
 import Unsupported from '@/views/Unsupported.vue'
-
-import Header from '@/components/Header.vue'
-import Footer from '@/components/Footer.vue'
-
-import chromeShortcutsJson from '@/assets/chrome.json'
 
 const isUnsupportedBrowser = navigator.userAgent.indexOf('Chrome') === -1
 const isUnsupportedOs = navigator.userAgent.indexOf('Mac') === -1

--- a/src/components/KeyList.vue
+++ b/src/components/KeyList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Key from './Key.vue'
+import Key from '@/components/Key.vue'
 
 defineProps<{ keys: string[] }>()
 </script>

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import GameKey from '@/stores/gameKey'
+import { injectStrict } from '@/utils'
+
+const { countsOfEachStatus } = injectStrict(GameKey)
+
+const CIRCUMFERENCE = 100
+const RADIUS = CIRCUMFERENCE / Math.PI / 2
+
+const isShowCircleDescription = ref(false)
+const showCircleDescription = () => {
+  isShowCircleDescription.value = true
+}
+const hideCircleDescription = () => {
+  isShowCircleDescription.value = false
+}
+
+const strokeDashArray = (
+  sumOfPreviousCounts: number,
+  count: number,
+  totalCount: number = totalCountOfIncluded.value
+) => {
+  const alreadyPaintedSize = (sumOfPreviousCounts / totalCount) * 100
+  const paintSize = (count / totalCount) * 100
+
+  if (sumOfPreviousCounts + count === totalCount) {
+    return `0 ${alreadyPaintedSize} ${100 - alreadyPaintedSize} 0`
+  } else {
+    return `0 ${alreadyPaintedSize} ${paintSize} ${
+      100 - (alreadyPaintedSize + paintSize)
+    }`
+  }
+}
+
+type status = 'mastered' | 'unmastered' | 'noAnswered'
+type subStatus = 'included' | 'removed'
+const styleOfEachStatus = {
+  mastered: {
+    name: '身についた',
+    included: {
+      bgColor: 'bg-green-300',
+      strokeColor: 'stroke-green-300',
+    },
+    removed: {
+      bgColor: 'bg-gray-700',
+      strokeColor: 'stroke-gray-700',
+    },
+  },
+  unmastered: {
+    name: '身についていない',
+    included: {
+      bgColor: 'bg-red-300',
+      strokeColor: 'stroke-red-300',
+    },
+    removed: {
+      bgColor: 'bg-gray-700',
+      strokeColor: 'stroke-gray-700',
+    },
+  },
+  noAnswered: {
+    name: '未回答',
+    included: {
+      bgColor: 'bg-gray-300',
+      strokeColor: 'stroke-gray-300',
+    },
+    removed: {
+      bgColor: 'bg-gray-700',
+      strokeColor: 'stroke-gray-700',
+    },
+  },
+}
+
+const totalCountOfIncluded = computed(() => {
+  return Object.values(countsOfEachStatus.value).reduce(
+    (previous, { included }) => previous + included,
+    0
+  )
+})
+
+const totalCountOfRemoved = computed(() => {
+  return Object.values(countsOfEachStatus.value).reduce(
+    (previous, { removed }) => previous + removed,
+    0
+  )
+})
+
+const rateOf = (
+  count: number,
+  totalCount: number = totalCountOfIncluded.value
+) => {
+  return Math.floor((count / totalCount) * 100)
+}
+
+const isAllMastered = computed(
+  () =>
+    countsOfEachStatus.value.mastered.included === totalCountOfIncluded.value
+)
+
+const subStatusOrder = ['included', 'removed']
+const statuses = computed(() => {
+  let sumOfPreviousCounts = 0
+
+  const statuses = Object.entries(countsOfEachStatus.value)
+    .flatMap(([status, { included, removed }]) => {
+      return [
+        {
+          status,
+          subStatus: 'included',
+          count: included,
+        },
+        {
+          status,
+          subStatus: 'removed',
+          count: removed,
+        },
+      ]
+    })
+    .sort((a, b) => {
+      return (
+        subStatusOrder.indexOf(a.subStatus) -
+        subStatusOrder.indexOf(b.subStatus)
+      )
+    })
+    .filter(({ subStatus }) => subStatus === 'included')
+    .map(({ status, subStatus, count }) => {
+      sumOfPreviousCounts += count
+      return {
+        count,
+        strokeColor:
+          styleOfEachStatus[status as status][subStatus as subStatus]
+            .strokeColor,
+        attributes: {
+          cx: '50%',
+          cy: '50%',
+          r: RADIUS,
+          style: {
+            'stroke-dasharray': strokeDashArray(
+              sumOfPreviousCounts - count,
+              count
+            ),
+          },
+        },
+      }
+    })
+
+  return statuses
+})
+</script>
+
+<template>
+  <div class="flex-initial h-48 flex justify-center">
+    <svg
+      class="origin-center -rotate-90 fill-transparent stroke-[3]"
+      data-testid="pie-chart"
+      viewBox="0 0 64 64"
+      @mouseleave="hideCircleDescription"
+      @mouseover="showCircleDescription"
+    >
+      <!-- eslint-disable -->
+      <template v-for="(status, key, index) in statuses">
+        <circle v-bind="status.attributes" :class="status.strokeColor" />
+      </template>
+      <!-- eslint-enable -->
+
+      <text
+        text-anchor="middle"
+        dominant-baseline="central"
+        class="origin-center rotate-90 fill-slate-700"
+      >
+        <tspan x="50%" y="45%" class="text-[0.8rem] font-sans">
+          {{ rateOf(countsOfEachStatus.mastered.included) }}
+        </tspan>
+        <tspan :x="isAllMastered ? '69%' : '66%'" y="50%" class="text-[0.3rem]">
+          %
+        </tspan>
+        <tspan x="50%" y="60%" class="text-[0.25rem]">身についた</tspan>
+      </text>
+    </svg>
+  </div>
+</template>

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -151,6 +151,48 @@ const statuses = computed(() => {
 
 <template>
   <div class="flex-initial h-48 flex justify-center">
+    <div
+      v-if="isShowCircleDescription"
+      class="text-left bg-white absolute z-10 left-1/2 translate-x-[5rem] top-[10%] border-2 border-gray-500 rounded-lg p-2"
+    >
+      <table class="border-separate" style="border-spacing: 0 0.25rem">
+        <thead class="text-xs">
+          <tr>
+            <th colspan="2" class="border-b p-1">ステータス</th>
+            <th class="border-b px-2 py-0.5 text-right">個数</th>
+            <th class="border-b px-2 py-0.5 text-center">比率</th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- eslint-disable -->
+          <template v-for="(subStatus, status) in countsOfEachStatus">
+            <tr
+              class="text-base"
+              :class="styleOfEachStatus[status].included.bgColor"
+            >
+              <td class="px-1">
+                {{ styleOfEachStatus[status].name }}
+              </td>
+
+              <td class="px-1 py-0.5"></td>
+              <td class="px-2 py-0.5 text-right">
+                {{ countsOfEachStatus[status].included }}
+              </td>
+              <td class="px-2 py-0.5 text-right">
+                {{ rateOf(countsOfEachStatus[status].included)
+                }}<span class="p-0.5 text-xs">%</span>
+              </td>
+            </tr>
+          </template>
+          <!-- eslint-enable -->
+        </tbody>
+      </table>
+
+      <span class="mx-2 text-sm"
+        >※ 出題しないリスト: {{ totalCountOfRemoved }}個</span
+      >
+    </div>
+
     <svg
       class="origin-center -rotate-90 fill-transparent stroke-[3]"
       data-testid="pie-chart"

--- a/src/components/PressedKeyCombination.vue
+++ b/src/components/PressedKeyCombination.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import KeyList from '@/components/KeyList.vue'
 import GameKey from '@/stores/gameKey'
-import KeyList from './KeyList.vue'
 import { injectStrict } from '@/utils'
 
 const { state } = injectStrict(GameKey)

--- a/src/components/QuestionShow.vue
+++ b/src/components/QuestionShow.vue
@@ -2,17 +2,17 @@
 import GameKey from '@/stores/gameKey'
 import { injectStrict } from '@/utils'
 
-const { state, shortcut } = injectStrict(GameKey)
+const { state } = injectStrict(GameKey)
 </script>
 
 <template>
   <div class="flex-initial h-32 flex flex-col">
-    <span>{{ shortcut.app }} | {{ shortcut.category }}</span>
+    <span>{{ state.shortcut.app }} | {{ state.shortcut.category }}</span>
     <h2
       class="w-4/5 break-words text-3xl md:text-4xl font-bold m-auto"
       :class="state.isRemoveKeyPressed ? 'animate-[fadeOut_1000ms]' : ''"
     >
-      {{ shortcut.action }}
+      {{ state.shortcut.action }}
     </h2>
   </div>
 </template>

--- a/src/components/RestoreButton.vue
+++ b/src/components/RestoreButton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import GameKey from '@/stores/gameKey'
 import { RefreshIcon } from '@heroicons/vue/outline'
+
+import GameKey from '@/stores/gameKey'
 import { injectStrict } from '@/utils'
 
 const { removedShortcutExists, restoreRemovedShortcuts } = injectStrict(GameKey)

--- a/src/components/ResultShow.vue
+++ b/src/components/ResultShow.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import GameKey from '@/stores/gameKey'
-import { CheckCircleIcon, CheckIcon } from '@heroicons/vue/solid'
 import { XCircleIcon } from '@heroicons/vue/outline'
-import KeyList from './KeyList.vue'
+import { CheckCircleIcon, CheckIcon } from '@heroicons/vue/solid'
+
+import KeyList from '@/components/KeyList.vue'
+import GameKey from '@/stores/gameKey'
 import { injectStrict } from '@/utils'
 
 const { state, correctKeys } = injectStrict(GameKey)

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,8 +1,7 @@
-import specialCodeToKeyArray from '@/constants/specialCodeToKeyArray'
 import defaultKeyboardLayoutArray from '@/constants/defaultKeyboardLayoutArray'
-import keyToSymbolArray from '@/constants/keyToSymbolArray'
 import keyToDisplayNameArray from '@/constants/keyToDisplayNameArray'
-
+import keyToSymbolArray from '@/constants/keyToSymbolArray'
+import specialCodeToKeyArray from '@/constants/specialCodeToKeyArray'
 import { NavigatorKeyboard } from '@/types/interfaces'
 
 const specialCodeToKeyMap = new Map<string, string>(specialCodeToKeyArray)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
-import { createApp } from 'vue'
-import App from '@/App.vue'
 import '@/index.css'
+
+import { createApp } from 'vue'
+
+import App from '@/App.vue'
 
 createApp(App).mount('#app')

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,12 +1,12 @@
-import { reactive, readonly, computed } from 'vue'
+import { computed, reactive, readonly } from 'vue'
 
-import { Shortcut, KeyCombinable } from '@/types/interfaces'
 import KeyCombination from '@/models/keyCombination'
+import { KeyCombinable, Shortcut } from '@/types/interfaces'
 import {
   getItemFromLocalStorage,
-  setItemToLocalStorage,
   loadAnsweredHistory,
   saveAnsweringHistory,
+  setItemToLocalStorage,
   weight,
   weightedSampleIndex,
 } from '@/utils'

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -3,16 +3,16 @@ import { computed, reactive, readonly } from 'vue'
 import KeyCombination from '@/models/keyCombination'
 import { KeyCombinable, Shortcut } from '@/types/interfaces'
 import {
-  getItemFromLocalStorage,
   loadAnsweredHistory,
-  saveAnsweringHistory,
-  setItemToLocalStorage,
+  loadRemovedIds,
+  saveAnsweredHistory,
+  saveRemovedIds,
   weight,
   weightedSampleKey,
 } from '@/utils'
 
 const TimeIntervalToRestartTyping = import.meta.env.MODE === 'test' ? 0 : 1000
-const removedIds = [...getItemFromLocalStorage('removedIds')]
+const removedIds = [...loadRemovedIds()]
 
 const gameStore = (shortcuts: Shortcut[]) => {
   const state = reactive({
@@ -169,7 +169,7 @@ const gameStore = (shortcuts: Shortcut[]) => {
     state.isListeningKeyboardEvent = false
     state.isRemoveKeyPressed = true
     state.removedIdSet.add(state.shortcut.id)
-    setItemToLocalStorage('removedIds', [...state.removedIdSet])
+    saveRemovedIds([...state.removedIdSet])
 
     setTimeout(() => {
       state.shortcut = nextShortcut()
@@ -210,7 +210,7 @@ const gameStore = (shortcuts: Shortcut[]) => {
       state.answeredHistoryMap.set(id, [result])
     }
 
-    saveAnsweringHistory(state.answeredHistoryMap)
+    saveAnsweredHistory(state.answeredHistoryMap)
   }
 
   const resetTypingState = () => {

--- a/src/stores/gameKey.ts
+++ b/src/stores/gameKey.ts
@@ -1,5 +1,6 @@
 import { InjectionKey } from 'vue'
-import { GameStore } from './game'
+
+import { GameStore } from '@/stores/game'
 
 const GameKey: InjectionKey<GameStore> = Symbol('gameStore')
 export default GameKey

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,26 @@ export function saveAnsweringHistory(answeredHistory: Map<string, boolean[]>) {
   localStorage.setItem(KEY_OF_RESULT_HISTORY, parsed)
 }
 
+export function weightedSampleKey(keyWeightMap: Map<string, number>) {
+  const keys = Array.from(keyWeightMap.keys())
+  const weights = Array.from(keyWeightMap.values())
+
+  return keys[weightedSampleIndex(weights)]
+}
+
+const weightedSampleIndex = (weights: number[]) => {
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0)
+  const randomWeight = Math.random() * totalWeight
+  let cumulativeWeight = 0
+
+  const sampledIndex = weights.findIndex((weight) => {
+    cumulativeWeight += weight
+    return cumulativeWeight >= randomWeight
+  })
+
+  return sampledIndex
+}
+
 /**
  * Examples of arg and returnValue:
  * [true, true] -> 0.02,
@@ -66,19 +86,6 @@ export function weight(results: boolean[]) {
   )
 
   return weight
-}
-
-export function weightedSampleIndex(weights: number[]) {
-  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0)
-  const randomWeight = Math.random() * totalWeight
-  let cumulativeWeight = 0
-
-  const sampledIndex = weights.findIndex((weight) => {
-    cumulativeWeight += weight
-    return cumulativeWeight >= randomWeight
-  })
-
-  return sampledIndex
 }
 
 export function noAnsweredAvailableIds(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { InjectionKey, inject } from 'vue'
+import { inject, InjectionKey } from 'vue'
+
 import { Shortcut } from '@/types/interfaces'
 
 // https://logaretm.com/blog/type-safe-provide-inject/

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,23 @@ export function setItemToLocalStorage(key: string, value: string[]) {
   const parsed = JSON.stringify(value)
   localStorage.setItem(key, parsed)
 }
+
+const KEY_OF_RESULT_HISTORY = 'answeredHistory_Version_0_0_0'
+
+export function loadAnsweredHistory(): Map<string, boolean[]> {
+  if (!localStorage.getItem(KEY_OF_RESULT_HISTORY)) return new Map()
+
+  try {
+    const json = localStorage.getItem(KEY_OF_RESULT_HISTORY) as string
+    const parsedJson = JSON.parse(json)
+    return new Map(Object.entries(parsedJson))
+  } catch (e) {
+    localStorage.removeItem(KEY_OF_RESULT_HISTORY)
+    return new Map()
+  }
+}
+
+export function saveAnsweringHistory(answeredHistory: Map<string, boolean[]>) {
+  const parsed = JSON.stringify(Object.fromEntries(answeredHistory))
+  localStorage.setItem(KEY_OF_RESULT_HISTORY, parsed)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { InjectionKey, inject } from 'vue'
+import { Shortcut } from '@/types/interfaces'
 
 // https://logaretm.com/blog/type-safe-provide-inject/
 export function injectStrict<T>(key: InjectionKey<T>, fallback?: T) {
@@ -44,4 +45,49 @@ export function loadAnsweredHistory(): Map<string, boolean[]> {
 export function saveAnsweringHistory(answeredHistory: Map<string, boolean[]>) {
   const parsed = JSON.stringify(Object.fromEntries(answeredHistory))
   localStorage.setItem(KEY_OF_RESULT_HISTORY, parsed)
+}
+
+/**
+ * Examples of arg and returnValue:
+ * [true, true] -> 0.02,
+ * [true] -> 0.51,
+ * [true, false] -> 3.51,
+ * [false] -> 5,
+ * [false, false] -> 9
+ */
+export function weight(results: boolean[]) {
+  const laterResults = results.slice(-2) // Last 2 results
+
+  const initialWeight = 1
+  const weight = laterResults.reduce(
+    (previousWeight, result) => previousWeight + (result ? -0.49 : 4),
+    initialWeight
+  )
+
+  return weight
+}
+
+export function weightedSampleIndex(weights: number[]) {
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0)
+  const randomWeight = Math.random() * totalWeight
+  let cumulativeWeight = 0
+
+  const sampledIndex = weights.findIndex((weight) => {
+    cumulativeWeight += weight
+    return cumulativeWeight >= randomWeight
+  })
+
+  return sampledIndex
+}
+
+export function noAnsweredAvailableIds(
+  shortcuts: Shortcut[],
+  removedIds: string[],
+  answeredHistoryMap: Map<string, boolean[]>
+) {
+  const answeredIds = Array.from(answeredHistoryMap.keys())
+
+  return shortcuts
+    .map((shortcut) => shortcut.id)
+    .filter((id) => !answeredIds.includes(id) && !removedIds.includes(id))
 }

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { provide } from 'vue'
 
+import PieChart from '@/components/PieChart.vue'
 import PressedKeyCombination from '@/components/PressedKeyCombination.vue'
 import QuestionShow from '@/components/QuestionShow.vue'
 import RestoreButton from '@/components/RestoreButton.vue'
@@ -47,6 +48,7 @@ useKeyboardEventListener('keyup', handleKeyUp)
 
 <template>
   <div v-if="!isAllRemoved">
+    <PieChart />
     <QuestionShow />
     <ResultShow />
     <PressedKeyCombination />

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -24,7 +24,7 @@ const props = defineProps<{ shortcuts: Shortcut[] }>()
 
 const game = gameStore(props.shortcuts)
 provide(GameKey, game)
-const { keyDown, keyUp, isEnded, restart } = game
+const { keyDown, keyUp, isAllRemoved, restart } = game
 
 const keyboard = new Keyboard()
 if ('keyboard' in navigator)
@@ -50,7 +50,7 @@ useKeyboardEventListener('keyup', handleKeyUp)
 </script>
 
 <template>
-  <div v-if="!isEnded">
+  <div v-if="!isAllRemoved">
     <QuestionShow />
     <ResultShow />
     <PressedKeyCombination />
@@ -62,7 +62,7 @@ useKeyboardEventListener('keyup', handleKeyUp)
       class="bg-blue-900 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-fit mx-auto"
       @click="restart()"
     >
-      もう1回
+      出題しないリストを空にする
     </button>
   </div>
 </template>

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -1,24 +1,20 @@
 <script setup lang="ts">
 import { provide } from 'vue'
 
+import PressedKeyCombination from '@/components/PressedKeyCombination.vue'
+import QuestionShow from '@/components/QuestionShow.vue'
+import RestoreButton from '@/components/RestoreButton.vue'
+import ResultShow from '@/components/ResultShow.vue'
+import ShortcutsShow from '@/components/ShortcutsShow.vue'
+import useKeyboardEventListener from '@/composables/useKeyboardEventListener'
+import Keyboard from '@/keyboard'
+import gameStore from '@/stores/game'
+import GameKey from '@/stores/gameKey'
 import {
   NavigatorExtend,
   NavigatorKeyboard,
   Shortcut,
 } from '@/types/interfaces'
-
-import gameStore from '@/stores/game'
-import GameKey from '@/stores/gameKey'
-
-import QuestionShow from '@/components/QuestionShow.vue'
-import ResultShow from '@/components/ResultShow.vue'
-import PressedKeyCombination from '@/components/PressedKeyCombination.vue'
-import ShortcutsShow from '@/components/ShortcutsShow.vue'
-import RestoreButton from '@/components/RestoreButton.vue'
-
-import useKeyboardEventListener from '@/composables/useKeyboardEventListener'
-
-import Keyboard from '@/keyboard'
 
 const props = defineProps<{ shortcuts: Shortcut[] }>()
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+
 import App from '@/App.vue'
 
 test('show an unsupported message when a client is unsupported', async () => {

--- a/test/gameView.test.ts
+++ b/test/gameView.test.ts
@@ -267,3 +267,16 @@ test('show an unanswered shortcut key as the highest priority', async () => {
 
   getByText('ウィンドウを最小化する')
 })
+
+test('show the current mastered ratio', async () => {
+  const { getByText, container } = render(GameView, {
+    props: { shortcuts: shortcuts },
+  })
+
+  expect(container.querySelector('svg')?.textContent).toEqual('0 % 身についた')
+
+  getByText('最後のタブに移動する')
+  await userEvent.keyboard('{Meta>}{9}')
+
+  expect(container.querySelector('svg')?.textContent).toEqual('50 % 身についた')
+})

--- a/test/gameView.test.ts
+++ b/test/gameView.test.ts
@@ -1,15 +1,15 @@
+import userEvent from '@testing-library/user-event'
 import {
   render,
-  waitForElementToBeRemoved,
-  waitFor,
-  within,
   screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
 } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
 
-import GameView from '@/views/GameView.vue'
 import Keyboard from '@/keyboard'
 import { loadAnsweredHistory } from '@/utils'
+import GameView from '@/views/GameView.vue'
 
 const shortcuts = [
   {

--- a/test/gameView.test.ts
+++ b/test/gameView.test.ts
@@ -68,16 +68,32 @@ test('show a question', () => {
   getByText('最後のタブに移動する')
 })
 
-test('show a pressed key combination', async () => {
-  const { getByTestId } = render(GameView, { props: { shortcuts: shortcuts } })
+test.each([
+  { keyCombination: '{A}', keys: ['a'] },
+  { keyCombination: '{Meta>}{A}', keys: ['Meta', 'a'] },
+  { keyCombination: '{Shift>}{A}', keys: ['Shift', 'a'] },
+  { keyCombination: '{Control>}{A}', keys: ['Control', 'a'] },
+  { keyCombination: '{Alt>}{A}', keys: ['Alt', 'a'] },
+  {
+    keyCombination: '{Meta>}{Shift>}{Control>}{Alt>}{A}',
+    keys: ['Meta', 'Shift', 'Control', 'Alt', 'a'],
+  },
+])(
+  'show keys of $keys when press $keyCombination',
+  async ({ keyCombination, keys }) => {
+    const { getByTestId } = render(GameView, {
+      props: { shortcuts: shortcuts },
+    })
 
-  await userEvent.keyboard('{Meta>}{A}')
+    await userEvent.keyboard(keyCombination)
 
-  const pressedKeyCombination = getByTestId('pressed-key-combination')
+    const pressedKeyCombination = getByTestId('pressed-key-combination')
 
-  within(pressedKeyCombination).getByTestId('Meta')
-  within(pressedKeyCombination).getByTestId('a')
-})
+    keys.forEach((key) => {
+      within(pressedKeyCombination).getByTestId(key)
+    })
+  }
+)
 
 test('proceed to a next question when the correct key is pressed', async () => {
   const { getByText, getByTestId } = render(GameView, {

--- a/test/gameView.test.ts
+++ b/test/gameView.test.ts
@@ -235,3 +235,19 @@ test('increase the frequency of the shortcut keys answered incorrectly', async (
 
   expect(frequencyOfShortcutAnsweredIncorrectly).toBeGreaterThan(70) // 頻度の差を示しつつ、ほぼ必ず成功する値とした
 })
+
+test('show an unanswered shortcut key as the highest priority', async () => {
+  const { getByText, getByTestId } = render(GameView, {
+    props: { shortcuts: shortcuts },
+  })
+
+  getByText('最後のタブに移動する')
+  await userEvent.keyboard('{Meta>}{9}')
+  await waitForElementToBeRemoved(getByTestId('check-circle-icon'))
+
+  getByText('ウィンドウを最小化する')
+
+  await userEvent.keyboard('{Enter}')
+
+  getByText('ウィンドウを最小化する')
+})

--- a/test/gameView.test.ts
+++ b/test/gameView.test.ts
@@ -129,7 +129,7 @@ test('skip a question when an Enter key is pressed', async () => {
   getByText('ウィンドウを最小化する')
 })
 
-test('remove a question when an D key is pressed', async () => {
+test('remove a question when an R key is pressed', async () => {
   const { getByText } = render(GameView, {
     props: { shortcuts: shortcuts },
   })
@@ -143,14 +143,12 @@ test('remove a question when an D key is pressed', async () => {
   getByText('ウィンドウを最小化する')
 
   await userEvent.keyboard('{Enter}')
-  await userEvent.click(screen.getByText('もう1回'))
-  document.body.focus()
 
   getByText('ウィンドウを最小化する')
 
   await userEvent.keyboard('{Enter}')
 
-  getByText('もう1回')
+  getByText('ウィンドウを最小化する')
 })
 
 test('removed shortcut keys are stored in localStorage', async () => {
@@ -211,4 +209,29 @@ test('save a record of incorrect answer when the incorrect key is pressed', () =
   userEvent.keyboard('{Meta>}{A}')
 
   expect(loadAnsweredHistory().get(shortcuts[0].id)).toStrictEqual([false])
+})
+
+test('increase the frequency of the shortcut keys answered incorrectly', async () => {
+  const { getByText, getByTestId, queryByText } = render(GameView, {
+    props: { shortcuts: shortcuts },
+  })
+
+  getByText('最後のタブに移動する')
+  await userEvent.keyboard('{Meta>}{9}') // 正解
+  await waitForElementToBeRemoved(getByTestId('check-circle-icon'))
+
+  getByText('ウィンドウを最小化する')
+  await userEvent.keyboard('{Meta>}{9}') // 不正解
+  await waitFor(() => getByText('ショートカットキーを入力してください...'))
+
+  let frequencyOfShortcutAnsweredIncorrectly = 0
+  for (let i = 0; i < 100; i++) {
+    await userEvent.keyboard('{Enter}')
+
+    if (queryByText('ウィンドウを最小化する')) {
+      frequencyOfShortcutAnsweredIncorrectly++
+    }
+  }
+
+  expect(frequencyOfShortcutAnsweredIncorrectly).toBeGreaterThan(70) // 頻度の差を示しつつ、ほぼ必ず成功する値とした
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 /// <reference types="vitest" />
 
-import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## 目的

#10 の対応

## 併せて取り組んだ Issue

「判定結果として何を記録するか」を考えるために、次の機能も考慮する必要があることに気づいたため、併せて実装することとした

- [x] #14
- [x] #13
- [x] #11

## やったこと

身についていないショートカットキーの出題頻度を高くするために、次のような実装をした

### ショートカットキー単位で回答結果（正誤判定結果）の履歴を持たせる

- 正解した場合:  履歴に`true` を追加
- 不正解の場合: 履歴に`false` を追加

履歴を保持することで、スコアのみ(-1, 0, 1 のどれかのみ）を保持する場合よりも、その後の活用方法の選択肢が広がるというメリットがある

### 誤りの多いショートカットキーの出題頻度を高くする

ショートカットキーごとに選択される確率を重み付けする

初期値は 1 とする

「回答結果（正誤判定結果）の履歴」から直近 2 回分の履歴を取得し、次のように重み付けする

- 正解なら -0.49
    - 初めに「-0.4」で試した結果、ほぼ全て正解した状態になると残り数個の不正解が出現しにくかったため、「-0.49」に調整した
- 不正解なら + 4.0

重み付けした結果は次のようになる

```
直近2回とも不正解: 9 // [false, false]
一度回答して不正解: 5 // [false]
直近2回中1回正解: 3.51 // [true, false]
一度回答して正解: 0.51 // [true]
直近2回とも正解: 0.02 // [true, true]


未回答: 1 // []
※未回答のショートカットキーは最優先で出題するため、重み付けの計算対象としてこのパターンが入力されることはない
```

### 「身についた」度合いを示す円グラフと表を表示

出題対象のショートカットキー（すなわち「身につけたい」ショートカットキー）の中での比率を表示することとした
表はグラフにホバーすると表示される

![image](https://user-images.githubusercontent.com/15713392/159625702-051864d9-7885-4187-a970-37f29029b95c.png)

出題しないリストをグラフに含めない（比率の計算から除いた）理由は、「出題しない」と設定しているということは興味のないショートカットキーということを示しており、興味のないショートカットキーに関する情報は表示しなくても良く、仮に表示した場合グラフや表が複雑になりパッと見てよくわからなくなってしまうため