### PR TITLE
Add more valid key combinations in full screen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://shortype.vercel.app/
 - Just type the shortcut key to train
 - All shortcut keys from the official documentation are available
 - Automatically increases the frequency of unmastered shortcut keys
-- Focus on the shortcut keys you want to learn by excluding non-interesting shortcut keys
+- Focus on the shortcut keys you want to master by excluding non-interesting shortcut keys
 
 ## Available apps for training
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-shortcut-keys",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/src/constants/keyCombinations.ts
+++ b/src/constants/keyCombinations.ts
@@ -2,13 +2,6 @@
 export const DENY_LIST_OF_KEY_COMBINATION = [
   {
     altKey: false,
-    ctrlKey: false,
-    metaKey: true,
-    shiftKey: false,
-    key: 'q',
-  },
-  {
-    altKey: false,
     ctrlKey: true,
     metaKey: false,
     shiftKey: false,
@@ -51,6 +44,13 @@ export const KEY_COMBINATIONS_ONLY_AVAILABLE_IN_FULL_SCREEN_MODE = [
     metaKey: true,
     shiftKey: true,
     key: 'n',
+  },
+  {
+    altKey: false,
+    ctrlKey: false,
+    metaKey: true,
+    shiftKey: false,
+    key: 'q',
   },
   {
     altKey: false,

--- a/src/constants/keyCombinations.ts
+++ b/src/constants/keyCombinations.ts
@@ -8,20 +8,6 @@ export const DENY_LIST_OF_KEY_COMBINATION = [
     key: 'q',
   },
   {
-    altKey: true,
-    ctrlKey: false,
-    metaKey: true,
-    shiftKey: false,
-    key: 'ArrowLeft',
-  },
-  {
-    altKey: true,
-    ctrlKey: false,
-    metaKey: true,
-    shiftKey: false,
-    key: 'ArrowRight',
-  },
-  {
     altKey: false,
     ctrlKey: true,
     metaKey: false,
@@ -93,5 +79,19 @@ export const KEY_COMBINATIONS_ONLY_AVAILABLE_IN_FULL_SCREEN_MODE = [
     metaKey: false,
     shiftKey: true,
     key: 'Tab',
+  },
+  {
+    altKey: true,
+    ctrlKey: false,
+    metaKey: true,
+    shiftKey: false,
+    key: 'ArrowLeft',
+  },
+  {
+    altKey: true,
+    ctrlKey: false,
+    metaKey: true,
+    shiftKey: false,
+    key: 'ArrowRight',
   },
 ] as const

--- a/src/constants/shortcuts/chrome.json
+++ b/src/constants/shortcuts/chrome.json
@@ -298,7 +298,7 @@
     "app": "Google Chrome",
     "category": "タブとウィンドウのショートカット",
     "id": "15",
-    "isAvailable": false,
+    "isAvailable": true,
     "keyCombinations": [
       {
         "altKey": false,
@@ -311,7 +311,7 @@
     "needsFillInBlankMode": false,
     "os": "macOS",
     "shortcut": "⌘+q",
-    "unavailableReason": "hasDeniedKeyCombination"
+    "unavailableReason": null
   },
   {
     "action": "キーボード フォーカスのあるタブを左右に移動する",

--- a/src/constants/shortcuts/chrome.json
+++ b/src/constants/shortcuts/chrome.json
@@ -84,7 +84,7 @@
     "app": "Google Chrome",
     "category": "タブとウィンドウのショートカット",
     "id": "5",
-    "isAvailable": false,
+    "isAvailable": true,
     "keyCombinations": [
       {
         "altKey": true,
@@ -97,14 +97,14 @@
     "needsFillInBlankMode": false,
     "os": "macOS",
     "shortcut": "⌘+option+右矢印",
-    "unavailableReason": "hasDeniedKeyCombination"
+    "unavailableReason": null
   },
   {
     "action": "開いている前のタブに移動する",
     "app": "Google Chrome",
     "category": "タブとウィンドウのショートカット",
     "id": "6",
-    "isAvailable": false,
+    "isAvailable": true,
     "keyCombinations": [
       {
         "altKey": true,
@@ -117,7 +117,7 @@
     "needsFillInBlankMode": false,
     "os": "macOS",
     "shortcut": "⌘+option+左矢印",
-    "unavailableReason": "hasDeniedKeyCombination"
+    "unavailableReason": null
   },
   {
     "action": "特定のタブに移動する",

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -4,6 +4,7 @@ export interface NavigatorExtend extends Navigator {
 
 export interface NavigatorKeyboard {
   getLayoutMap(): Promise<Map<string, string>>
+  lock(): void
 }
 
 export interface KeyCombinable {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { inject, InjectionKey } from 'vue'
 
-import { Shortcut } from '@/types/interfaces'
+import { NavigatorExtend, Shortcut } from '@/types/interfaces'
 
 // https://logaretm.com/blog/type-safe-provide-inject/
 export function injectStrict<T>(key: InjectionKey<T>, fallback?: T) {
@@ -207,5 +207,12 @@ export function toggleFullscreen() {
     if (document.exitFullscreen) {
       document.exitFullscreen()
     }
+  }
+}
+
+export function lockKeyboard() {
+  const navigatorExtend = navigator as NavigatorExtend
+  if ('keyboard' in navigatorExtend && 'lock' in navigatorExtend.keyboard) {
+    navigatorExtend.keyboard.lock()
   }
 }

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -18,6 +18,7 @@ import {
   NavigatorKeyboard,
   Shortcut,
 } from '@/types/interfaces'
+import { lockKeyboard } from '@/utils'
 
 const props = withDefaults(
   defineProps<{ shortcuts: Shortcut[]; isShowToolModal?: boolean }>(),
@@ -32,10 +33,12 @@ provide(GameKey, game)
 const { keyDown, keyUp, isAllRemoved, onFullscreenchange } = game
 
 const keyboard = new Keyboard()
-if ('keyboard' in navigator)
+if ('keyboard' in navigator) {
   keyboard.setKeyboardLayoutMap(
     (navigator as NavigatorExtend).keyboard as NavigatorKeyboard
   )
+  lockKeyboard()
+}
 
 const handleKeyDown = (e: KeyboardEvent) => {
   const { altKey, metaKey, shiftKey, ctrlKey } = e


### PR DESCRIPTION
## やったこと

動作確認をしていて以下に気づいたので、対応した

- 全画面モードで入力可能な Opt + Cmd + ←/→ が入力不可として扱われていたので修正
- 全画面モードのときに Esc キーを入力すると全画面モードが OFF に切り替わってしまうため、[Keyboard.lock](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/lock) を使って無効化（長押しすると全画面モードを OFF にできる）した
    - また、Keyboard.lock を使った結果、Cmd + Q も無効化できたので、併せて全画面モードで入力可能なキーとして扱うようにした