### PR TITLE
[codex] refactor shortcut training session identifiers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ Shortype is a shortcut key training app.
 
 ## Vocabulary Rules
 
-- Prefer **app** over **tool** when talking about the training target.
+- Prefer **tool** over **app** when talking about the training target.
 - Prefer **removed shortcut** or **do not ask list** over raw storage key names.
 - Prefer **training session** over the Vue store name when talking about behavior and rules.
 - Prefer **mastered rate** over implementation details like weights.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Context
+
+Shortype is a shortcut key training app.
+
+## Domain Terms
+
+- **App**: one training target such as Google Chrome, Terminal (macOS), or macOS.
+- **Shortcut**: one action shown to the learner, with one or more valid key combinations.
+- **Shortcut catalog**: the full set of shortcuts available for an app.
+- **Training session**: the active loop where one shortcut is shown, input is judged, and the next shortcut is chosen.
+- **Selected app**: the app currently used for training.
+- **Selected categories**: the category set currently used for training.
+- **Available shortcut**: a shortcut that can be trained normally.
+- **Removed shortcut**: a shortcut placed into the "do not ask" list.
+- **Answered history**: the record of correct and incorrect answers for each shortcut.
+- **Mastered**: a shortcut whose recent answer weight is low enough to count as learned.
+- **Mastered rate**: the percentage of mastered shortcuts within an app or category.
+- **Self-scoring**: the flow where a learner checks the answer and marks it correct or wrong manually.
+- **Fill-in-the-blank mode**: the mode used when the shortcut description contains mouse actions, other actions, or undetectable keys.
+- **Fullscreen-only shortcut**: a shortcut that can only be judged correctly while fullscreen mode is active.
+
+## Vocabulary Rules
+
+- Prefer **app** over **tool** when talking about the training target.
+- Prefer **removed shortcut** or **do not ask list** over raw storage key names.
+- Prefer **training session** over the Vue store name when talking about behavior and rules.
+- Prefer **mastered rate** over implementation details like weights.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "files": {
+    "includes": ["**", "!**/dist"]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space"

--- a/data/create-shortcut.ts
+++ b/data/create-shortcut.ts
@@ -1,0 +1,129 @@
+import { DENY_LIST_OF_KEY_COMBINATION } from '@/constants/key-combinations'
+import {
+  ALT_DESCRIPTION_REGEXP,
+  CTRL_DESCRIPTION_REGEXP,
+  DENY_LIST_OF_KEY_DESCRIPTION_REGEXP,
+  FUNCTION_KEY_DESCRIPTION_REGEXP,
+  KEY_DESCRIPTION_EXCLUDING_MODIFIER_REGEXP,
+  META_DESCRIPTION_REGEXP,
+  MODIFIER_KEY_DESCRIPTION_REGEXP,
+  SHIFT_DESCRIPTION_REGEXP,
+  UNDETECTABLE_KEY_DESCRIPTION_REGEXP,
+} from '@/constants/key-description-regexp'
+import KEY_DESCRIPTION_TO_KEY_MAP from '@/constants/key-description-to-key-map'
+import {
+  MODIFIED_KEY_REGEXP,
+  UNDETECTABLE_KEY_REGEXP,
+} from '@/constants/key-regexp'
+import {
+  HAS_MOUSE_ACTIONS_REGEXP,
+  HAS_MULTIPLE_ANSWERS_REGEXP,
+  HAS_OTHER_ACTIONS_REGEXP,
+  HAS_RANGED_ANSWERS_REGEXP,
+  IS_DEPEND_ON_DEVICE_REGEXP,
+  NEEDS_CUSTOMIZED_MODIFIER_KEY_REGEXP,
+} from '@/constants/shortcut-description-regexp'
+import KeyCombination from '@/models/key-combination'
+import type { Shortcut, ShortcutDescription } from '@/types/interfaces'
+
+const deniedKeyCombinations = DENY_LIST_OF_KEY_COMBINATION.map(
+  (deniedKeyCombination) => new KeyCombination(deniedKeyCombination),
+)
+
+export const createShortcut = (shortcutRaw: ShortcutDescription) => {
+  const shortcut: Shortcut = {
+    id: shortcutRaw.id,
+    app: shortcutRaw.app,
+    os: shortcutRaw.os,
+    category: shortcutRaw.category,
+    action: shortcutRaw.action,
+    keysDescription: shortcutRaw.keysDescription,
+    keyCombinations: extractKeyCombinations(shortcutRaw.keysDescription),
+    isAvailable: false,
+    unavailableReason: null,
+    needsFillInBlankMode: false,
+  }
+
+  if (NEEDS_CUSTOMIZED_MODIFIER_KEY_REGEXP.test(shortcut.keysDescription)) {
+    shortcut.unavailableReason = 'needsCustomizedModifierKey'
+  } else if (IS_DEPEND_ON_DEVICE_REGEXP.test(shortcut.keysDescription)) {
+    shortcut.unavailableReason = 'isDependOnDevice'
+  } else if (
+    shortcut.keyCombinations.every((keyCombination) =>
+      KeyCombination.isDefaultValue(keyCombination),
+    )
+  ) {
+    shortcut.unavailableReason = 'hasOnlyNonKeyAction'
+  } else if (HAS_RANGED_ANSWERS_REGEXP.test(shortcut.keysDescription)) {
+    shortcut.unavailableReason = 'hasRangedAnswers'
+  } else if (
+    deniedKeyCombinations.some((deniedKeyCombination) =>
+      shortcut.keyCombinations.some((keyCombination) =>
+        deniedKeyCombination.is(keyCombination),
+      ),
+    )
+  ) {
+    shortcut.unavailableReason = 'hasDeniedKeyCombination'
+  } else if (
+    shortcut.keyCombinations.some((keyCombination) =>
+      MODIFIED_KEY_REGEXP.test(keyCombination.key as string),
+    )
+  ) {
+    shortcut.unavailableReason = 'hasModifiedKey'
+  } else {
+    shortcut.isAvailable = true
+  }
+
+  shortcut.needsFillInBlankMode = needsFillInBlankMode(shortcut.keysDescription)
+
+  return shortcut
+}
+
+const extractKeyCombinations = (shortcutDescriptions: string) => {
+  return shortcutDescriptions
+    .replaceAll(DENY_LIST_OF_KEY_DESCRIPTION_REGEXP, '')
+    .replaceAll(UNDETECTABLE_KEY_DESCRIPTION_REGEXP, '')
+    .split(HAS_MULTIPLE_ANSWERS_REGEXP)
+    .filter(
+      (shortcutDescription) =>
+        !FUNCTION_KEY_DESCRIPTION_REGEXP.test(shortcutDescription),
+    )
+    .map((shortcutDescription) => {
+      return {
+        altKey: ALT_DESCRIPTION_REGEXP.test(shortcutDescription),
+        ctrlKey: CTRL_DESCRIPTION_REGEXP.test(shortcutDescription),
+        metaKey: META_DESCRIPTION_REGEXP.test(shortcutDescription),
+        shiftKey: SHIFT_DESCRIPTION_REGEXP.test(shortcutDescription),
+        key: extractKey(shortcutDescription),
+      }
+    })
+}
+
+const extractKey = (shortcutDescription: string) => {
+  const matched = shortcutDescription
+    .replaceAll(MODIFIER_KEY_DESCRIPTION_REGEXP, '')
+    .replaceAll(DENY_LIST_OF_KEY_DESCRIPTION_REGEXP, '')
+    .replaceAll(UNDETECTABLE_KEY_DESCRIPTION_REGEXP, '')
+    .match(KEY_DESCRIPTION_EXCLUDING_MODIFIER_REGEXP)
+
+  if (matched) {
+    let matchedKey = matched[0] as string
+
+    if (UNDETECTABLE_KEY_REGEXP.test(matchedKey)) return null
+
+    matchedKey = KEY_DESCRIPTION_TO_KEY_MAP.get(matchedKey) ?? matchedKey
+    matchedKey = matchedKey.length === 1 ? matchedKey.toLowerCase() : matchedKey
+
+    return matchedKey
+  } else {
+    return null
+  }
+}
+
+const needsFillInBlankMode = (description: string) => {
+  return (
+    HAS_MOUSE_ACTIONS_REGEXP.test(description) ||
+    HAS_OTHER_ACTIONS_REGEXP.test(description) ||
+    UNDETECTABLE_KEY_DESCRIPTION_REGEXP.test(description)
+  )
+}

--- a/data/create-shortcuts-core.ts
+++ b/data/create-shortcuts-core.ts
@@ -1,6 +1,6 @@
 import type { Shortcut, ShortcutDescription } from '@/types/interfaces'
 
-import { createShortcut } from './create-shortcuts'
+import { createShortcut } from './create-shortcut'
 
 export const createShortcutsFromRecords = (
   records: ShortcutDescription[],

--- a/data/create-shortcuts-core.ts
+++ b/data/create-shortcuts-core.ts
@@ -1,0 +1,7 @@
+import type { Shortcut, ShortcutDescription } from '@/types/interfaces'
+
+import { createShortcut } from './create-shortcuts'
+
+export const createShortcutsFromRecords = (
+  records: ShortcutDescription[],
+): Shortcut[] => records.map((record) => createShortcut(record))

--- a/data/create-shortcuts.ts
+++ b/data/create-shortcuts.ts
@@ -1,40 +1,11 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-import { DENY_LIST_OF_KEY_COMBINATION } from '@/constants/key-combinations'
-import {
-  ALT_DESCRIPTION_REGEXP,
-  CTRL_DESCRIPTION_REGEXP,
-  DENY_LIST_OF_KEY_DESCRIPTION_REGEXP,
-  FUNCTION_KEY_DESCRIPTION_REGEXP,
-  KEY_DESCRIPTION_EXCLUDING_MODIFIER_REGEXP,
-  META_DESCRIPTION_REGEXP,
-  MODIFIER_KEY_DESCRIPTION_REGEXP,
-  SHIFT_DESCRIPTION_REGEXP,
-  UNDETECTABLE_KEY_DESCRIPTION_REGEXP,
-} from '@/constants/key-description-regexp'
-import KEY_DESCRIPTION_TO_KEY_MAP from '@/constants/key-description-to-key-map'
-import {
-  MODIFIED_KEY_REGEXP,
-  UNDETECTABLE_KEY_REGEXP,
-} from '@/constants/key-regexp'
-import {
-  HAS_MOUSE_ACTIONS_REGEXP,
-  HAS_MULTIPLE_ANSWERS_REGEXP,
-  HAS_OTHER_ACTIONS_REGEXP,
-  HAS_RANGED_ANSWERS_REGEXP,
-  IS_DEPEND_ON_DEVICE_REGEXP,
-  NEEDS_CUSTOMIZED_MODIFIER_KEY_REGEXP,
-} from '@/constants/shortcut-description-regexp'
-import KeyCombination from '@/models/key-combination'
-import type { Shortcut, ShortcutDescription } from '@/types/interfaces'
+import type { ShortcutDescription } from '@/types/interfaces'
 
+import { createShortcut } from './create-shortcut'
 import { createShortcutsFromRecords } from './create-shortcuts-core'
 import { parseCsv } from './parse-csv'
-
-const deniedKeyCombinations = DENY_LIST_OF_KEY_COMBINATION.map(
-  (deniedKeyCombination) => new KeyCombination(deniedKeyCombination),
-)
 
 export default async function createShortcuts(csvPath: string) {
   const csvRawData = fs.readFileSync(csvPath)
@@ -47,103 +18,5 @@ export default async function createShortcuts(csvPath: string) {
     `${__dirname}/../src/constants/shortcuts/${filename}.json`,
     json,
     'utf8',
-  )
-}
-
-export const createShortcut = (shortcutRaw: ShortcutDescription) => {
-  const shortcut: Shortcut = {
-    id: shortcutRaw.id,
-    app: shortcutRaw.app,
-    os: shortcutRaw.os,
-    category: shortcutRaw.category,
-    action: shortcutRaw.action,
-    keysDescription: shortcutRaw.keysDescription,
-    keyCombinations: extractKeyCombinations(shortcutRaw.keysDescription),
-    isAvailable: false,
-    unavailableReason: null,
-    needsFillInBlankMode: false,
-  }
-
-  if (NEEDS_CUSTOMIZED_MODIFIER_KEY_REGEXP.test(shortcut.keysDescription)) {
-    shortcut.unavailableReason = 'needsCustomizedModifierKey'
-  } else if (IS_DEPEND_ON_DEVICE_REGEXP.test(shortcut.keysDescription)) {
-    shortcut.unavailableReason = 'isDependOnDevice'
-  } else if (
-    shortcut.keyCombinations.every((keyCombination) =>
-      KeyCombination.isDefaultValue(keyCombination),
-    )
-  ) {
-    shortcut.unavailableReason = 'hasOnlyNonKeyAction'
-  } else if (HAS_RANGED_ANSWERS_REGEXP.test(shortcut.keysDescription)) {
-    shortcut.unavailableReason = 'hasRangedAnswers'
-  } else if (
-    deniedKeyCombinations.some((deniedKeyCombination) =>
-      shortcut.keyCombinations.some((keyCombination) =>
-        deniedKeyCombination.is(keyCombination),
-      ),
-    )
-  ) {
-    shortcut.unavailableReason = 'hasDeniedKeyCombination'
-  } else if (
-    shortcut.keyCombinations.some((keyCombination) =>
-      MODIFIED_KEY_REGEXP.test(keyCombination.key as string),
-    )
-  ) {
-    shortcut.unavailableReason = 'hasModifiedKey'
-  } else {
-    shortcut.isAvailable = true
-  }
-
-  shortcut.needsFillInBlankMode = needsFillInBlankMode(shortcut.keysDescription)
-
-  return shortcut
-}
-
-const extractKeyCombinations = (shortcutDescriptions: string) => {
-  return shortcutDescriptions
-    .replaceAll(DENY_LIST_OF_KEY_DESCRIPTION_REGEXP, '')
-    .replaceAll(UNDETECTABLE_KEY_DESCRIPTION_REGEXP, '')
-    .split(HAS_MULTIPLE_ANSWERS_REGEXP)
-    .filter(
-      (shortcutDescription) =>
-        !FUNCTION_KEY_DESCRIPTION_REGEXP.test(shortcutDescription),
-    )
-    .map((shortcutDescription) => {
-      return {
-        altKey: ALT_DESCRIPTION_REGEXP.test(shortcutDescription),
-        ctrlKey: CTRL_DESCRIPTION_REGEXP.test(shortcutDescription),
-        metaKey: META_DESCRIPTION_REGEXP.test(shortcutDescription),
-        shiftKey: SHIFT_DESCRIPTION_REGEXP.test(shortcutDescription),
-        key: extractKey(shortcutDescription),
-      }
-    })
-}
-
-const extractKey = (shortcutDescription: string) => {
-  const matched = shortcutDescription
-    .replaceAll(MODIFIER_KEY_DESCRIPTION_REGEXP, '')
-    .replaceAll(DENY_LIST_OF_KEY_DESCRIPTION_REGEXP, '')
-    .replaceAll(UNDETECTABLE_KEY_DESCRIPTION_REGEXP, '')
-    .match(KEY_DESCRIPTION_EXCLUDING_MODIFIER_REGEXP)
-
-  if (matched) {
-    let matchedKey = matched[0] as string
-
-    if (UNDETECTABLE_KEY_REGEXP.test(matchedKey)) return null
-
-    matchedKey = KEY_DESCRIPTION_TO_KEY_MAP.get(matchedKey) ?? matchedKey
-    matchedKey = matchedKey.length === 1 ? matchedKey.toLowerCase() : matchedKey
-
-    return matchedKey
-  } else {
-    return null
-  }
-}
-
-const needsFillInBlankMode = (description: string) => {
-  return (
-    HAS_MOUSE_ACTIONS_REGEXP.test(description) ||
-    HAS_OTHER_ACTIONS_REGEXP.test(description) ||
-    UNDETECTABLE_KEY_DESCRIPTION_REGEXP.test(description)
   )
 }

--- a/data/create-shortcuts.ts
+++ b/data/create-shortcuts.ts
@@ -2,8 +2,6 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import type { ShortcutDescription } from '@/types/interfaces'
-
-import { createShortcut } from './create-shortcut'
 import { createShortcutsFromRecords } from './create-shortcuts-core'
 import { parseCsv } from './parse-csv'
 

--- a/data/create-shortcuts.ts
+++ b/data/create-shortcuts.ts
@@ -28,6 +28,8 @@ import {
 } from '@/constants/shortcut-description-regexp'
 import KeyCombination from '@/models/key-combination'
 import type { Shortcut, ShortcutDescription } from '@/types/interfaces'
+
+import { createShortcutsFromRecords } from './create-shortcuts-core'
 import { parseCsv } from './parse-csv'
 
 const deniedKeyCombinations = DENY_LIST_OF_KEY_COMBINATION.map(
@@ -38,13 +40,7 @@ export default async function createShortcuts(csvPath: string) {
   const csvRawData = fs.readFileSync(csvPath)
   const filename = path.basename(csvPath, '.csv')
   const records = parseCsv(csvRawData) as unknown as ShortcutDescription[]
-
-  const shortcuts: Shortcut[] = []
-  for (const record of records) {
-    const shortcut = createShortcut(record)
-
-    shortcuts.push(shortcut)
-  }
+  const shortcuts = createShortcutsFromRecords(records)
 
   const json = JSON.stringify(shortcuts)
   fs.writeFileSync(

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,8 +13,8 @@ const modal = modalStore()
 provide(ModalKey, modal)
 const { modalState } = modal
 
-const isUnsupportedBrowser = navigator.userAgent.indexOf('Chrome') === -1
-const isUnsupportedOs = navigator.userAgent.indexOf('Mac') === -1
+const isUnsupportedBrowser = !navigator.userAgent.includes('Chrome')
+const isUnsupportedOs = !navigator.userAgent.includes('Mac')
 const isUnsupported = ref(isUnsupportedBrowser || isUnsupportedOs)
 const proceed = () => {
   isUnsupported.value = false

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,12 +4,12 @@ import { provide, ref } from 'vue'
 import About from '@/components/About.vue'
 import Footer from '@/components/Footer.vue'
 import Header from '@/components/Header.vue'
-import modalStore from '@/stores/modal'
+import createModalStore from '@/stores/modal'
 import ModalKey from '@/stores/modal-key'
 import GameView from '@/views/GameView.vue'
 import Unsupported from '@/views/Unsupported.vue'
 
-const modal = modalStore()
+const modal = createModalStore()
 provide(ModalKey, modal)
 const { modalState } = modal
 
@@ -35,9 +35,8 @@ const proceed = () => {
       />
       <GameView
         v-else
-        :is-show-tool-modal="modalState.isShowToolsAndCategoriesModal"
       />
-      <About :is-show="modalState.isShowAboutModal" />
+      <About :is-show="modalState.isAboutModalVisible" />
     </main>
     <Footer />
   </div>

--- a/src/components/CategorySelect.vue
+++ b/src/components/CategorySelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
 import Button from '@/components/Button.vue'
 import CategoryCard from '@/components/CategoryCard.vue'
@@ -13,19 +13,24 @@ const emit = defineEmits(['select-tool-and-categories', 'reset-tool'])
 
 const categoriesWithRate = categoriesWithMasteredRate(props.tool)
 const targetCategories = categoriesWithRate.map((category) => category.name)
+const targetCategorySet = new Set(targetCategories)
 const selectedCategories = ref(new Set(props.categories))
 
-const hasSelectedCategory = computed(() =>
-  targetCategories.some((categoryName) =>
-    selectedCategories.value.has(categoryName)
-  )
-)
+const hasSelectedCategory = () => {
+  for (const categoryName of targetCategorySet) {
+    if (selectedCategories.value.has(categoryName)) return true
+  }
 
-const isSelectedAllCategories = computed(() =>
-  targetCategories.every((categoryName) =>
-    selectedCategories.value.has(categoryName)
-  )
-)
+  return false
+}
+
+const isSelectedAllCategories = () => {
+  for (const categoryName of targetCategorySet) {
+    if (!selectedCategories.value.has(categoryName)) return false
+  }
+
+  return true
+}
 
 const toggleCategory = (categoryName: string) => {
   selectedCategories.value.has(categoryName)
@@ -68,7 +73,7 @@ const rejectAllCategories = () => {
     <div class="flex justify-around w-10/12 pb-1">
       <Button
         :name="'すべて選ぶ'"
-        :is-disabled="isSelectedAllCategories"
+        :is-disabled="isSelectedAllCategories()"
         @click="selectAllCategories()"
       >
         <template #icon>
@@ -82,7 +87,7 @@ const rejectAllCategories = () => {
       </Button>
       <Button
         :name="'すべての選択を外す'"
-        :is-disabled="!hasSelectedCategory"
+        :is-disabled="!hasSelectedCategory()"
         @click="rejectAllCategories()"
       >
         <template #icon>
@@ -107,7 +112,7 @@ const rejectAllCategories = () => {
     <Button
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold px-4 py-2 my-4"
       :name="'選んだカテゴリーの練習をはじめる'"
-      :is-disabled="!hasSelectedCategory"
+      :is-disabled="!hasSelectedCategory()"
       @click="emit('select-tool-and-categories', [...selectedCategories])"
     />
   </div>

--- a/src/components/CategorySelect.vue
+++ b/src/components/CategorySelect.vue
@@ -12,20 +12,20 @@ const props = defineProps<{ tool: string; categories: string[] }>()
 const emit = defineEmits(['select-tool-and-categories', 'reset-tool'])
 
 const categoriesWithRate = categoriesWithMasteredRate(props.tool)
-const targetCategories = categoriesWithRate.map((category) => category.name)
-const targetCategorySet = new Set(targetCategories)
+const selectableCategories = categoriesWithRate.map((category) => category.name)
+const selectableCategorySet = new Set(selectableCategories)
 const selectedCategories = ref(new Set(props.categories))
 
-const hasSelectedCategory = () => {
-  for (const categoryName of targetCategorySet) {
+const hasAnySelectedCategory = () => {
+  for (const categoryName of selectableCategorySet) {
     if (selectedCategories.value.has(categoryName)) return true
   }
 
   return false
 }
 
-const isSelectedAllCategories = () => {
-  for (const categoryName of targetCategorySet) {
+const areAllCategoriesSelected = () => {
+  for (const categoryName of selectableCategorySet) {
     if (!selectedCategories.value.has(categoryName)) return false
   }
 
@@ -39,13 +39,13 @@ const toggleCategory = (categoryName: string) => {
 }
 
 const selectAllCategories = () => {
-  for (const categoryName of targetCategories) {
+  for (const categoryName of selectableCategories) {
     selectedCategories.value.add(categoryName)
   }
 }
 
-const rejectAllCategories = () => {
-  for (const categoryName of targetCategories) {
+const deselectAllCategories = () => {
+  for (const categoryName of selectableCategories) {
     selectedCategories.value.delete(categoryName)
   }
 }
@@ -73,7 +73,7 @@ const rejectAllCategories = () => {
     <div class="flex justify-around w-10/12 pb-1">
       <Button
         :name="'すべて選ぶ'"
-        :is-disabled="isSelectedAllCategories()"
+        :is-disabled="areAllCategoriesSelected()"
         @click="selectAllCategories()"
       >
         <template #icon>
@@ -87,8 +87,8 @@ const rejectAllCategories = () => {
       </Button>
       <Button
         :name="'すべての選択を外す'"
-        :is-disabled="!hasSelectedCategory()"
-        @click="rejectAllCategories()"
+        :is-disabled="!hasAnySelectedCategory()"
+        @click="deselectAllCategories()"
       >
         <template #icon>
           <div class="self-center h-5 w-5 rounded-full border-2 border-gray-300" />
@@ -112,7 +112,7 @@ const rejectAllCategories = () => {
     <Button
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold px-4 py-2 my-4"
       :name="'選んだカテゴリーの練習をはじめる'"
-      :is-disabled="!hasSelectedCategory()"
+      :is-disabled="!hasAnySelectedCategory()"
       @click="emit('select-tool-and-categories', [...selectedCategories])"
     />
   </div>

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -84,55 +84,32 @@ const rateOf = (
   return Math.floor((count / totalCount) * 100)
 }
 
-const subStatusOrder = ['included', 'removed']
+const statusOrder = ['mastered', 'unmastered', 'noAnswered'] as const
 const statuses = computed(() => {
   let sumOfPreviousCounts = 0
 
-  const statuses = Object.entries(countsOfEachStatus.value)
-    .flatMap(([status, { included, removed }]) => {
-      return [
-        {
-          status,
-          subStatus: 'included',
-          count: included,
-        },
-        {
-          status,
-          subStatus: 'removed',
-          count: removed,
-        },
-      ]
-    })
-    .sort((a, b) => {
-      return (
-        subStatusOrder.indexOf(a.subStatus) -
-        subStatusOrder.indexOf(b.subStatus)
-      )
-    })
-    .filter(({ subStatus }) => subStatus === 'included')
-    .map(({ status, subStatus, count }) => {
-      sumOfPreviousCounts += count
-      return {
-        count,
-        strokeColor:
-          styleOfEachStatus[status as 'mastered' | 'unmastered' | 'noAnswered'][
-            subStatus as 'included' | 'removed'
-          ].strokeColor,
-        attributes: {
-          cx: '50%',
-          cy: '50%',
-          r: RADIUS,
-          style: {
-            'stroke-dasharray': strokeDashArray(
-              sumOfPreviousCounts - count,
-              count
-            ),
-          },
-        },
-      }
-    })
+  return statusOrder.map((status) => {
+    const { included } = countsOfEachStatus.value[status]
+    const count = included
 
-  return statuses
+    sumOfPreviousCounts += count
+
+    return {
+      count,
+      strokeColor: styleOfEachStatus[status].included.strokeColor,
+      attributes: {
+        cx: '50%',
+        cy: '50%',
+        r: RADIUS,
+        style: {
+          'stroke-dasharray': strokeDashArray(
+            sumOfPreviousCounts - count,
+            count,
+          ),
+        },
+      },
+    }
+  })
 })
 </script>
 

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -57,7 +57,7 @@ const styleOfEachStatus = {
       strokeColor: 'stroke-gray-700',
     },
   },
-  noAnswered: {
+  unanswered: {
     name: '未回答',
     included: {
       bgColor: 'bg-gray-300',
@@ -84,7 +84,7 @@ const rateOf = (
   return Math.floor((count / totalCount) * 100)
 }
 
-const statusOrder = ['mastered', 'unmastered', 'noAnswered'] as const
+const statusOrder = ['mastered', 'unmastered', 'unanswered'] as const
 const statuses = computed(() => {
   let sumOfPreviousCounts = 0
 

--- a/src/components/ToolCard.vue
+++ b/src/components/ToolCard.vue
@@ -2,7 +2,7 @@
 import IconGlyph from '@/components/IconGlyph.vue'
 import PieChartOfMasteredRate from '@/components/PieChartOfMasteredRate.vue'
 
-defineProps<{ app: string; masteredRate: number }>()
+defineProps<{ toolName: string; masteredRate: number }>()
 </script>
 
 <template>
@@ -10,7 +10,7 @@ defineProps<{ app: string; masteredRate: number }>()
     type="button"
     class="flex justify-between w-10/12 h-20 bg-white rounded-lg border border-gray-200 shadow-md hover:bg-gray-100 transition duration-200 hover:ease-out"
   >
-    <h3 class="my-auto mx-4 text-xl font-bold tracking-tight">{{ app }}</h3>
+    <h3 class="my-auto mx-4 text-xl font-bold tracking-tight">{{ toolName }}</h3>
 
     <div class="flex h-20">
       <PieChartOfMasteredRate :mastered-rate="masteredRate" />

--- a/src/components/ToolSelect.vue
+++ b/src/components/ToolSelect.vue
@@ -15,11 +15,11 @@ const emit = defineEmits(['select-tool'])
     </div>
 
     <ToolCard
-      v-for="(app, index) in masteredRateOfEachTool()"
+      v-for="(toolSummary, index) in masteredRateOfEachTool()"
       :key="index"
-      :app="app.name"
-      :mastered-rate="app.masteredRate"
-      @click="emit('select-tool', app.name)"
+      :tool-name="toolSummary.name"
+      :mastered-rate="toolSummary.masteredRate"
+      @click="emit('select-tool', toolSummary.name)"
     />
   </div>
 </template>

--- a/src/components/ToolsAndCategoriesModal.vue
+++ b/src/components/ToolsAndCategoriesModal.vue
@@ -11,7 +11,6 @@ import { injectStrict } from '@/utils/inject-strict'
 
 const { state, selectToolAndCategories } = injectStrict(GameKey)
 const { modalState, hideToolsAndCategoriesModal } = injectStrict(ModalKey)
-defineProps<{ isShow: boolean }>()
 
 const tool = ref('')
 
@@ -25,7 +24,8 @@ const select = (categories: string[]) => {
   <Modal
     ref="modal"
     :is-show="
-      state.isSelectToolsKeyPressed || modalState.isShowToolsAndCategoriesModal
+      state.isSelectToolsKeyPressed ||
+      modalState.isToolsAndCategoriesModalVisible
     "
   >
     <ModalContent :is-show="tool === ''" :is-enter-from-right="true">
@@ -37,6 +37,7 @@ const select = (categories: string[]) => {
         :categories="[...state.categories]"
         @select-tool-and-categories="(categories) => select(categories)"
         @reset-tool="tool = ''"
-      /> </ModalContent
-  ></Modal>
+      />
+    </ModalContent>
+  </Modal>
 </template>

--- a/src/models/empty-shortcut.ts
+++ b/src/models/empty-shortcut.ts
@@ -1,0 +1,14 @@
+import type { Shortcut } from '@/types/interfaces'
+
+export const createEmptyShortcut = (): Shortcut => ({
+  id: '',
+  app: '',
+  os: '',
+  category: '',
+  action: '',
+  keysDescription: '',
+  keyCombinations: [],
+  isAvailable: false,
+  unavailableReason: null,
+  needsFillInBlankMode: false,
+})

--- a/src/models/key-combination.ts
+++ b/src/models/key-combination.ts
@@ -84,7 +84,7 @@ export default class KeyCombination {
   }
 
   constructor(
-    private keyCombinable: KeyCombinable = KeyCombination.defaultValue,
+    public keyCombinable: KeyCombinable = KeyCombination.defaultValue,
   ) {}
 
   keyDown(keyCombinable: KeyCombinable) {

--- a/src/models/key-combination.ts
+++ b/src/models/key-combination.ts
@@ -1,6 +1,25 @@
 import { KEY_COMBINATIONS_ONLY_AVAILABLE_IN_FULL_SCREEN_MODE } from '@/constants/key-combinations'
 import type { KeyCombinable } from '@/types/interfaces'
 
+const MODIFIER_KEY_SET = new Set(['Alt', 'Shift', 'Meta', 'Control'])
+const NON_KEY_SET = new Set([
+  'Alt',
+  'Shift',
+  'Meta',
+  'Control',
+  undefined,
+  null,
+])
+
+const signatureOf = (keyCombinable: KeyCombinable) =>
+  `${keyCombinable.altKey}-${keyCombinable.ctrlKey}-${keyCombinable.metaKey}-${keyCombinable.shiftKey}-${keyCombinable.key ?? ''}`
+
+const FULL_SCREEN_ONLY_SIGNATURE_SET = new Set(
+  KEY_COMBINATIONS_ONLY_AVAILABLE_IN_FULL_SCREEN_MODE.map((keyCombination) =>
+    signatureOf(keyCombination),
+  ),
+)
+
 export default class KeyCombination {
   static defaultValue = {
     altKey: false,
@@ -38,7 +57,7 @@ export default class KeyCombination {
     return (
       keyCombinable.key !== undefined &&
       keyCombinable.key !== null &&
-      ['Alt', 'Shift', 'Meta', 'Control'].includes(keyCombinable.key)
+      MODIFIER_KEY_SET.has(keyCombinable.key)
     )
   }
 
@@ -47,17 +66,8 @@ export default class KeyCombination {
     return altKey || ctrlKey || metaKey || shiftKey
   }
 
-  static keyCombinationsOnlyAvailableInFullscreen =
-    KEY_COMBINATIONS_ONLY_AVAILABLE_IN_FULL_SCREEN_MODE.map(
-      (keyCombinationOnlyAvailableInFullscreen) =>
-        new KeyCombination(keyCombinationOnlyAvailableInFullscreen),
-    )
-
   static isOnlyAvailableInFullscreen(keyCombinable: KeyCombinable) {
-    return KeyCombination.keyCombinationsOnlyAvailableInFullscreen.some(
-      (keyCombinationOnlyAvailableInFullscreen) =>
-        keyCombinationOnlyAvailableInFullscreen.is(keyCombinable),
-    )
+    return FULL_SCREEN_ONLY_SIGNATURE_SET.has(signatureOf(keyCombinable))
   }
 
   static extractKeys(keyCombinable: KeyCombinable) {
@@ -67,11 +77,7 @@ export default class KeyCombination {
     if (keyCombinable.altKey) keys.push('Alt')
     if (keyCombinable.shiftKey) keys.push('Shift')
     if (keyCombinable.ctrlKey) keys.push('Control')
-    if (
-      !['Alt', 'Shift', 'Meta', 'Control', undefined, null].includes(
-        keyCombinable.key,
-      )
-    )
+    if (!NON_KEY_SET.has(keyCombinable.key))
       keys.push(keyCombinable.key as string)
 
     return keys

--- a/src/models/shortcut-catalog-summary.ts
+++ b/src/models/shortcut-catalog-summary.ts
@@ -1,0 +1,16 @@
+import shortcutCatalog from '@/models/shortcut-catalog'
+import type { ShortcutCatalogSummary } from '@/models/shortcut-training-session-summary'
+
+export const createShortcutCatalogSummary = (): ShortcutCatalogSummary => ({
+  tools: shortcutCatalog.tools().map((tool) => ({
+    name: tool,
+    shortcuts: shortcutCatalog.where({ tool }),
+    categories: shortcutCatalog.categoriesOf(tool).map((categoryName) => ({
+      name: categoryName,
+      shortcuts: shortcutCatalog.where({
+        tool,
+        categories: [categoryName],
+      }),
+    })),
+  })),
+})

--- a/src/models/shortcut-catalog-summary.ts
+++ b/src/models/shortcut-catalog-summary.ts
@@ -2,15 +2,5 @@ import shortcutCatalog from '@/models/shortcut-catalog'
 import type { ShortcutCatalogSummary } from '@/models/shortcut-training-session-summary'
 
 export const createShortcutCatalogSummary = (): ShortcutCatalogSummary => ({
-  tools: shortcutCatalog.tools().map((tool) => ({
-    name: tool,
-    shortcuts: shortcutCatalog.where({ tool }),
-    categories: shortcutCatalog.categoriesOf(tool).map((categoryName) => ({
-      name: categoryName,
-      shortcuts: shortcutCatalog.where({
-        tool,
-        categories: [categoryName],
-      }),
-    })),
-  })),
+  tools: shortcutCatalog.listToolGroups(),
 })

--- a/src/models/shortcut-catalog.ts
+++ b/src/models/shortcut-catalog.ts
@@ -1,26 +1,90 @@
 import TOOL_TO_SHORTCUTS_MAP from '@/constants/tool-to-shortcuts-map'
 import type { Shortcut } from '@/types/interfaces'
 
-const shortcutCatalog = {
-  where: ({ tool, categories }: { tool: string; categories?: string[] }) => {
-    const shortcuts = TOOL_TO_SHORTCUTS_MAP.get(tool) as Shortcut[]
+export type ShortcutCatalogCategoryGroup = {
+  name: string
+  shortcuts: Shortcut[]
+}
 
-    if (!categories?.length) {
-      return shortcuts.map((shortcut) => shortcut)
+export type ShortcutCatalogToolGroup = {
+  name: string
+  shortcuts: Shortcut[]
+  categories: ShortcutCatalogCategoryGroup[]
+}
+
+const TOOL_GROUPS: ShortcutCatalogToolGroup[] = Array.from(
+  TOOL_TO_SHORTCUTS_MAP.entries(),
+).map(([tool, shortcuts]) => {
+  const categoryMap = new Map<string, Shortcut[]>()
+
+  for (const shortcut of shortcuts) {
+    const groupedShortcuts = categoryMap.get(shortcut.category)
+
+    if (groupedShortcuts) {
+      groupedShortcuts.push(shortcut)
+    } else {
+      categoryMap.set(shortcut.category, [shortcut])
+    }
+  }
+
+  return {
+    name: tool,
+    shortcuts,
+    categories: Array.from(categoryMap.entries()).map(
+      ([name, groupedShortcuts]) => ({
+        name,
+        shortcuts: groupedShortcuts,
+      }),
+    ),
+  }
+})
+
+const TOOL_GROUP_MAP = new Map(
+  TOOL_GROUPS.map((toolGroup) => [toolGroup.name, toolGroup] as const),
+)
+
+const getToolGroup = (tool: string): ShortcutCatalogToolGroup | undefined =>
+  TOOL_GROUP_MAP.get(tool)
+
+export type ShortcutCatalog = {
+  searchShortcuts: (args: { tool: string; categories?: string[] }) => Shortcut[]
+  listTools: () => string[]
+  listCategoriesOf: (tool: string) => string[]
+  listToolGroups: () => ShortcutCatalogToolGroup[]
+}
+
+const shortcutCatalog: ShortcutCatalog = {
+  searchShortcuts: ({
+    tool,
+    categories,
+  }: {
+    tool: string
+    categories?: string[]
+  }) => {
+    const toolGroup = getToolGroup(tool)
+
+    if (!toolGroup) {
+      return []
     }
 
-    return shortcuts
-      .filter((shortcut) => categories.includes(shortcut.category))
-      .map((shortcut) => shortcut)
+    if (!categories?.length) {
+      return [...toolGroup.shortcuts]
+    }
+
+    const categorySet = new Set(categories)
+
+    return toolGroup.shortcuts.filter((shortcut) =>
+      categorySet.has(shortcut.category),
+    )
   },
 
-  tools: () => Array.from(TOOL_TO_SHORTCUTS_MAP.keys()),
+  listTools: () => TOOL_GROUPS.map(({ name }) => name),
 
-  categoriesOf: (tool: string) => {
-    const shortcuts = TOOL_TO_SHORTCUTS_MAP.get(tool) ?? []
-
-    return Array.from(new Set(shortcuts.map((shortcut) => shortcut.category)))
+  listCategoriesOf: (tool: string) => {
+    return getToolGroup(tool)?.categories.map(({ name }) => name) ?? []
   },
+
+  listToolGroups: () => TOOL_GROUPS,
 }
 
 export default shortcutCatalog

--- a/src/models/shortcut-catalog.ts
+++ b/src/models/shortcut-catalog.ts
@@ -1,7 +1,7 @@
 import TOOL_TO_SHORTCUTS_MAP from '@/constants/tool-to-shortcuts-map'
 import type { Shortcut } from '@/types/interfaces'
 
-const shortcutStorage = {
+const shortcutCatalog = {
   where: ({ tool, categories }: { tool: string; categories?: string[] }) => {
     const shortcuts = TOOL_TO_SHORTCUTS_MAP.get(tool) as Shortcut[]
 
@@ -13,6 +13,14 @@ const shortcutStorage = {
       .filter((shortcut) => categories.includes(shortcut.category))
       .map((shortcut) => shortcut)
   },
+
+  tools: () => Array.from(TOOL_TO_SHORTCUTS_MAP.keys()),
+
+  categoriesOf: (tool: string) => {
+    const shortcuts = TOOL_TO_SHORTCUTS_MAP.get(tool) ?? []
+
+    return Array.from(new Set(shortcuts.map((shortcut) => shortcut.category)))
+  },
 }
 
-export default shortcutStorage
+export default shortcutCatalog

--- a/src/models/shortcut-training-session-effects.ts
+++ b/src/models/shortcut-training-session-effects.ts
@@ -1,4 +1,7 @@
-import type { ShortcutTrainingSessionDeps, ShortcutTrainingState } from '@/models/shortcut-training-session'
+import type {
+  ShortcutTrainingSessionDeps,
+  ShortcutTrainingState,
+} from '@/models/shortcut-training-session'
 
 export const createShortcutTrainingSessionEffects = (
   state: ShortcutTrainingState,

--- a/src/models/shortcut-training-session-effects.ts
+++ b/src/models/shortcut-training-session-effects.ts
@@ -2,6 +2,20 @@ import type {
   ShortcutTrainingSessionDeps,
   ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
+import type { Shortcut } from '@/types/interfaces'
+
+const createEmptyShortcut = (): Shortcut => ({
+  id: '',
+  app: '',
+  os: '',
+  category: '',
+  action: '',
+  keysDescription: '',
+  keyCombinations: [],
+  isAvailable: false,
+  unavailableReason: null,
+  needsFillInBlankMode: false,
+})
 
 export const createShortcutTrainingSessionEffects = (
   state: ShortcutTrainingState,
@@ -108,7 +122,7 @@ export const createShortcutTrainingSessionEffects = (
       deps.persistRemovedIds(new Set())
       state.removedIdSet = new Set<string>()
       resetTypingState()
-      state.shortcut = state.shortcuts[0]
+      state.shortcut = state.shortcuts[0] ?? createEmptyShortcut()
     }
   }
 

--- a/src/models/shortcut-training-session-effects.ts
+++ b/src/models/shortcut-training-session-effects.ts
@@ -1,0 +1,133 @@
+import type { ShortcutTrainingSessionDeps, ShortcutTrainingState } from '@/models/shortcut-training-session'
+
+export const createShortcutTrainingSessionEffects = (
+  state: ShortcutTrainingState,
+  deps: ShortcutTrainingSessionDeps,
+  nextShortcut: () => ShortcutTrainingState['shortcut'],
+  resetTypingState: () => void,
+) => {
+  const saveResult = (id: string, result: boolean) => {
+    if (state.answeredHistoryMap.has(id)) {
+      state.answeredHistoryMap.get(id)?.push(result)
+    } else {
+      state.answeredHistoryMap.set(id, [result])
+    }
+
+    deps.persistAnsweredHistory(state.answeredHistoryMap)
+  }
+
+  const restartTyping = (afterRestart: () => void) => {
+    deps.scheduleRestartTyping(() => {
+      afterRestart()
+      resetTypingState()
+      state.isListeningKeyboardEvent = true
+    })
+  }
+
+  const respondToSelectToolsKey = () => {
+    resetTypingState()
+    state.isListeningKeyboardEvent = false
+    state.isSelectToolsKeyPressed = true
+  }
+
+  const respondToShowCorrectKey = () => {
+    resetTypingState()
+    state.isShowCorrectKeyPressed = true
+  }
+
+  const respondToRemoveKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isRemoveKeyPressed = true
+    state.removedIdSet.add(state.shortcut.id)
+    deps.persistRemovedIds(state.removedIdSet)
+
+    restartTyping(() => {
+      state.shortcut = nextShortcut()
+    })
+  }
+
+  const respondToCorrectKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isCorrectKeyPressed = true
+
+    if (!state.isWrongKeyPressed) {
+      saveResult(state.shortcut.id, true)
+    }
+
+    restartTyping(() => {
+      state.shortcut = nextShortcut()
+    })
+  }
+
+  const respondToWrongKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isWrongKeyPressed = true
+    state.isShakingKeyCombinationView = true
+    saveResult(state.shortcut.id, false)
+
+    deps.scheduleRestartTyping(() => {
+      state.isListeningKeyboardEvent = true
+      state.isShakingKeyCombinationView = false
+      state.pressedKeyCombination.reset()
+    })
+  }
+
+  const respondToMarkSelfAsCorrectKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isMarkedSelfAsCorrect = true
+    saveResult(state.shortcut.id, true)
+
+    restartTyping(() => {
+      state.shortcut = nextShortcut()
+    })
+  }
+
+  const respondToMarkSelfAsWrongKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isMarkedSelfAsWrong = true
+    saveResult(state.shortcut.id, false)
+
+    restartTyping(() => {
+      state.shortcut = nextShortcut()
+    })
+  }
+
+  const toggleFullscreen = () => {
+    deps.toggleFullscreen()
+  }
+
+  const restoreRemovedShortcuts = () => {
+    if (
+      confirm(
+        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？',
+      )
+    ) {
+      deps.persistRemovedIds(new Set())
+      state.removedIdSet = new Set<string>()
+      resetTypingState()
+      state.shortcut = state.shortcuts[0]
+    }
+  }
+
+  const selectToolAndCategories = (tool: string, categories: string[]) => {
+    state.tool = tool
+    deps.persistSelectedTool(tool)
+
+    state.categories = new Set(categories)
+    deps.persistSelectedCategories(categories)
+  }
+
+  return {
+    saveResult,
+    respondToSelectToolsKey,
+    respondToShowCorrectKey,
+    respondToRemoveKey,
+    respondToCorrectKey,
+    respondToWrongKey,
+    respondToMarkSelfAsCorrectKey,
+    respondToMarkSelfAsWrongKey,
+    toggleFullscreen,
+    restoreRemovedShortcuts,
+    selectToolAndCategories,
+  }
+}

--- a/src/models/shortcut-training-session-effects.ts
+++ b/src/models/shortcut-training-session-effects.ts
@@ -1,21 +1,8 @@
+import { createEmptyShortcut } from '@/models/empty-shortcut'
 import type {
   ShortcutTrainingSessionDeps,
   ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
-import type { Shortcut } from '@/types/interfaces'
-
-const createEmptyShortcut = (): Shortcut => ({
-  id: '',
-  app: '',
-  os: '',
-  category: '',
-  action: '',
-  keysDescription: '',
-  keyCombinations: [],
-  isAvailable: false,
-  unavailableReason: null,
-  needsFillInBlankMode: false,
-})
 
 export const createShortcutTrainingSessionEffects = (
   state: ShortcutTrainingState,

--- a/src/models/shortcut-training-session-status.ts
+++ b/src/models/shortcut-training-session-status.ts
@@ -1,5 +1,5 @@
 import type { Shortcut } from '@/types/interfaces'
-import { weight } from '@/utils/weighted-sample'
+import { calculateWeight } from '@/utils/weighted-sample'
 
 export type ShortcutTrainingSessionStatusSnapshot = {
   shortcuts: Shortcut[]
@@ -14,7 +14,7 @@ type StatusCounts = {
 
 const MASTERED_WEIGHT_THRESHOLD = 0.6
 
-const shortcutsIds = (shortcuts: Shortcut[]) =>
+const shortcutIds = (shortcuts: Shortcut[]) =>
   shortcuts.map((shortcut) => shortcut.id)
 
 export const getIdToWeightMap = ({
@@ -22,11 +22,11 @@ export const getIdToWeightMap = ({
   answeredHistory,
 }: ShortcutTrainingSessionStatusSnapshot) => {
   const idToWeightMap = new Map<string, number>()
-  const shortcutIdSet = new Set(shortcutsIds(shortcuts))
+  const shortcutIdSet = new Set(shortcutIds(shortcuts))
 
   for (const [id, results] of answeredHistory.entries()) {
     if (shortcutIdSet.has(id)) {
-      idToWeightMap.set(id, weight(results))
+      idToWeightMap.set(id, calculateWeight(results))
     }
   }
 
@@ -58,13 +58,13 @@ export const getMasteredIds = (
 export const getCountsOfEachStatus = (
   snapshot: ShortcutTrainingSessionStatusSnapshot,
 ) => {
-  const shortcutsIdList = shortcutsIds(snapshot.shortcuts)
-  const availableIds = shortcutsIdList.filter(
+  const shortcutIdList = shortcutIds(snapshot.shortcuts)
+  const availableIds = shortcutIdList.filter(
     (id) => !snapshot.removedIds.has(id),
   )
   const availableIdSet = new Set(availableIds)
   const answeredIdSet = new Set(snapshot.answeredHistory.keys())
-  const noAnsweredIds = shortcutsIdList.filter((id) => !answeredIdSet.has(id))
+  const unansweredIds = shortcutIdList.filter((id) => !answeredIdSet.has(id))
   const idToWeightMap = getIdToWeightMap(snapshot)
 
   const count = (ids: Iterable<string>) => {
@@ -96,10 +96,10 @@ export const getCountsOfEachStatus = (
   return {
     mastered: count(masteredIds),
     unmastered: count(unmasteredIds),
-    noAnswered: count(noAnsweredIds),
+    unanswered: count(unansweredIds),
   } satisfies {
     mastered: StatusCounts
     unmastered: StatusCounts
-    noAnswered: StatusCounts
+    unanswered: StatusCounts
   }
 }

--- a/src/models/shortcut-training-session-status.ts
+++ b/src/models/shortcut-training-session-status.ts
@@ -62,17 +62,36 @@ export const getCountsOfEachStatus = (
   const availableIds = shortcutsIdList.filter(
     (id) => !snapshot.removedIds.has(id),
   )
+  const availableIdSet = new Set(availableIds)
   const answeredIdSet = new Set(snapshot.answeredHistory.keys())
-  const masteredIds = getMasteredIds(snapshot)
-  const unmasteredIds = Array.from(getIdToWeightMap(snapshot))
-    .filter(([, currentWeight]) => currentWeight > MASTERED_WEIGHT_THRESHOLD)
-    .map(([id]) => id)
   const noAnsweredIds = shortcutsIdList.filter((id) => !answeredIdSet.has(id))
+  const idToWeightMap = getIdToWeightMap(snapshot)
 
-  const count = (ids: string[]) => ({
-    included: ids.filter((id) => availableIds.includes(id)).length,
-    removed: ids.filter((id) => !availableIds.includes(id)).length,
-  })
+  const count = (ids: Iterable<string>) => {
+    let included = 0
+    let removed = 0
+
+    for (const id of ids) {
+      if (availableIdSet.has(id)) {
+        included += 1
+      } else {
+        removed += 1
+      }
+    }
+
+    return { included, removed }
+  }
+
+  const masteredIds: string[] = []
+  const unmasteredIds: string[] = []
+
+  for (const [id, currentWeight] of idToWeightMap.entries()) {
+    if (currentWeight <= MASTERED_WEIGHT_THRESHOLD) {
+      masteredIds.push(id)
+    } else {
+      unmasteredIds.push(id)
+    }
+  }
 
   return {
     mastered: count(masteredIds),

--- a/src/models/shortcut-training-session-status.ts
+++ b/src/models/shortcut-training-session-status.ts
@@ -1,0 +1,86 @@
+import type { Shortcut } from '@/types/interfaces'
+import { weight } from '@/utils/weighted-sample'
+
+export type ShortcutTrainingSessionStatusSnapshot = {
+  shortcuts: Shortcut[]
+  removedIds: ReadonlySet<string>
+  answeredHistory: ReadonlyMap<string, boolean[]>
+}
+
+type StatusCounts = {
+  included: number
+  removed: number
+}
+
+const MASTERED_WEIGHT_THRESHOLD = 0.6
+
+const shortcutsIds = (shortcuts: Shortcut[]) =>
+  shortcuts.map((shortcut) => shortcut.id)
+
+export const getIdToWeightMap = ({
+  shortcuts,
+  answeredHistory,
+}: ShortcutTrainingSessionStatusSnapshot) => {
+  const idToWeightMap = new Map<string, number>()
+  const shortcutIdSet = new Set(shortcutsIds(shortcuts))
+
+  for (const [id, results] of answeredHistory.entries()) {
+    if (shortcutIdSet.has(id)) {
+      idToWeightMap.set(id, weight(results))
+    }
+  }
+
+  return idToWeightMap
+}
+
+export const getAvailableIdToWeightMap = (
+  snapshot: ShortcutTrainingSessionStatusSnapshot,
+) => {
+  const availableIdToWeightMap = new Map<string, number>()
+  const idToWeightMap = getIdToWeightMap(snapshot)
+
+  for (const [id, currentWeight] of idToWeightMap.entries()) {
+    if (!snapshot.removedIds.has(id)) {
+      availableIdToWeightMap.set(id, currentWeight)
+    }
+  }
+
+  return availableIdToWeightMap
+}
+
+export const getMasteredIds = (
+  snapshot: ShortcutTrainingSessionStatusSnapshot,
+) =>
+  [...getIdToWeightMap(snapshot)]
+    .filter(([, currentWeight]) => currentWeight <= MASTERED_WEIGHT_THRESHOLD)
+    .map(([id]) => id)
+
+export const getCountsOfEachStatus = (
+  snapshot: ShortcutTrainingSessionStatusSnapshot,
+) => {
+  const shortcutsIdList = shortcutsIds(snapshot.shortcuts)
+  const availableIds = shortcutsIdList.filter(
+    (id) => !snapshot.removedIds.has(id),
+  )
+  const answeredIdSet = new Set(snapshot.answeredHistory.keys())
+  const masteredIds = getMasteredIds(snapshot)
+  const unmasteredIds = Array.from(getIdToWeightMap(snapshot))
+    .filter(([, currentWeight]) => currentWeight > MASTERED_WEIGHT_THRESHOLD)
+    .map(([id]) => id)
+  const noAnsweredIds = shortcutsIdList.filter((id) => !answeredIdSet.has(id))
+
+  const count = (ids: string[]) => ({
+    included: ids.filter((id) => availableIds.includes(id)).length,
+    removed: ids.filter((id) => !availableIds.includes(id)).length,
+  })
+
+  return {
+    mastered: count(masteredIds),
+    unmastered: count(unmasteredIds),
+    noAnswered: count(noAnsweredIds),
+  } satisfies {
+    mastered: StatusCounts
+    unmastered: StatusCounts
+    noAnswered: StatusCounts
+  }
+}

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -1,4 +1,3 @@
-import shortcutCatalog from '@/models/shortcut-catalog'
 import {
   getCountsOfEachStatus,
   getMasteredIds,
@@ -9,6 +8,17 @@ export type ShortcutTrainingSessionSnapshot = {
   shortcuts: Shortcut[]
   removedIds: Set<string>
   answeredHistory: Map<string, boolean[]>
+}
+
+export type ShortcutCatalogSummary = {
+  tools: Array<{
+    name: string
+    shortcuts: Shortcut[]
+    categories: Array<{
+      name: string
+      shortcuts: Shortcut[]
+    }>
+  }>
 }
 
 type StatusCounts = {
@@ -34,6 +44,7 @@ export type ShortcutTrainingSessionSummary = {
 
 export const createShortcutTrainingSessionSummary = (
   snapshot: ShortcutTrainingSessionSnapshot,
+  catalog: ShortcutCatalogSummary,
 ): ShortcutTrainingSessionSummary => {
   const countsOfEachStatus = () =>
     getCountsOfEachStatus({
@@ -45,8 +56,7 @@ export const createShortcutTrainingSessionSummary = (
   const masteredIds = () => getMasteredIds(snapshot)
 
   const masteredRateOfEachTool = () =>
-    shortcutCatalog.tools().map((tool) => {
-      const shortcuts = shortcutCatalog.where({ tool })
+    catalog.tools.map(({ name, shortcuts }) => {
       const countOfShortcut = shortcuts.filter(
         (shortcut) => !snapshot.removedIds.has(shortcut.id),
       ).length
@@ -57,7 +67,7 @@ export const createShortcutTrainingSessionSummary = (
       ).length
 
       return {
-        name: tool,
+        name,
         masteredRate:
           countOfShortcut === 0
             ? 0
@@ -66,13 +76,19 @@ export const createShortcutTrainingSessionSummary = (
     })
 
   const categoriesWithMasteredRate = (tool: string) => {
-    const shortcutsOfTool = shortcutCatalog.where({ tool })
     const masteredIdsOfTool = masteredIds()
+    const toolGroup = catalog.tools.find(({ name }) => name === tool)
 
-    return shortcutCatalog.categoriesOf(tool).map((categoryName) => {
-      const shortcutsOfCategory = shortcutsOfTool.filter(
+    if (!toolGroup) {
+      return []
+    }
+
+    const shortcutIdsOfTool = new Set(toolGroup.shortcuts.map(({ id }) => id))
+
+    return toolGroup.categories.map((category) => {
+      const shortcutsOfCategory = category.shortcuts.filter(
         (shortcut) =>
-          shortcut.category === categoryName &&
+          shortcutIdsOfTool.has(shortcut.id) &&
           !snapshot.removedIds.has(shortcut.id),
       )
       const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
@@ -80,7 +96,7 @@ export const createShortcutTrainingSessionSummary = (
       )
 
       return {
-        name: categoryName,
+        name: category.name,
         masteredRate:
           shortcutsOfCategory.length === 0
             ? 0

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -46,6 +46,11 @@ export const createShortcutTrainingSessionSummary = (
   snapshot: ShortcutTrainingSessionSnapshot,
   catalog: ShortcutCatalogSummary,
 ): ShortcutTrainingSessionSummary => {
+  const toolGroupMap = new Map(
+    catalog.tools.map((toolGroup) => [toolGroup.name, toolGroup] as const),
+  )
+  const masteredIdSet = new Set(getMasteredIds(snapshot))
+
   const countsOfEachStatus = () =>
     getCountsOfEachStatus({
       shortcuts: snapshot.shortcuts,
@@ -53,18 +58,22 @@ export const createShortcutTrainingSessionSummary = (
       answeredHistory: snapshot.answeredHistory,
     })
 
-  const masteredIds = () => getMasteredIds(snapshot)
+  const masteredRateOfEachTool = () => {
+    return catalog.tools.map(({ name, shortcuts }) => {
+      let countOfShortcut = 0
+      let countOfMastered = 0
 
-  const masteredRateOfEachTool = () =>
-    catalog.tools.map(({ name, shortcuts }) => {
-      const countOfShortcut = shortcuts.filter(
-        (shortcut) => !snapshot.removedIds.has(shortcut.id),
-      ).length
-      const countOfMastered = shortcuts.filter(
-        (shortcut) =>
-          masteredIds().includes(shortcut.id) &&
-          !snapshot.removedIds.has(shortcut.id),
-      ).length
+      for (const shortcut of shortcuts) {
+        if (snapshot.removedIds.has(shortcut.id)) {
+          continue
+        }
+
+        countOfShortcut += 1
+
+        if (masteredIdSet.has(shortcut.id)) {
+          countOfMastered += 1
+        }
+      }
 
       return {
         name,
@@ -74,25 +83,21 @@ export const createShortcutTrainingSessionSummary = (
             : Math.floor((countOfMastered / countOfShortcut) * 100),
       }
     })
+  }
 
   const categoriesWithMasteredRate = (tool: string) => {
-    const masteredIdsOfTool = masteredIds()
-    const toolGroup = catalog.tools.find(({ name }) => name === tool)
+    const toolGroup = toolGroupMap.get(tool)
 
     if (!toolGroup) {
       return []
     }
 
-    const shortcutIdsOfTool = new Set(toolGroup.shortcuts.map(({ id }) => id))
-
     return toolGroup.categories.map((category) => {
       const shortcutsOfCategory = category.shortcuts.filter(
-        (shortcut) =>
-          shortcutIdsOfTool.has(shortcut.id) &&
-          !snapshot.removedIds.has(shortcut.id),
+        (shortcut) => !snapshot.removedIds.has(shortcut.id),
       )
       const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
-        (shortcut) => masteredIdsOfTool.includes(shortcut.id),
+        (shortcut) => masteredIdSet.has(shortcut.id),
       )
 
       return {

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -30,7 +30,7 @@ export type ShortcutTrainingSessionSummary = {
   countsOfEachStatus: () => {
     mastered: StatusCounts
     unmastered: StatusCounts
-    noAnswered: StatusCounts
+    unanswered: StatusCounts
   }
   masteredRateOfEachTool: () => Array<{
     name: string
@@ -46,8 +46,10 @@ export const createShortcutTrainingSessionSummary = (
   snapshot: ShortcutTrainingSessionSnapshot,
   catalog: ShortcutCatalogSummary,
 ): ShortcutTrainingSessionSummary => {
-  const toolGroupMap = new Map(
-    catalog.tools.map((toolGroup) => [toolGroup.name, toolGroup] as const),
+  const toolByNameMap = new Map(
+    catalog.tools.map(
+      (toolSummary) => [toolSummary.name, toolSummary] as const,
+    ),
   )
   const masteredIdSet = new Set(getMasteredIds(snapshot))
 
@@ -60,54 +62,54 @@ export const createShortcutTrainingSessionSummary = (
 
   const masteredRateOfEachTool = () => {
     return catalog.tools.map(({ name, shortcuts }) => {
-      let countOfShortcut = 0
-      let countOfMastered = 0
+      let shortcutCount = 0
+      let masteredCount = 0
 
       for (const shortcut of shortcuts) {
         if (snapshot.removedIds.has(shortcut.id)) {
           continue
         }
 
-        countOfShortcut += 1
+        shortcutCount += 1
 
         if (masteredIdSet.has(shortcut.id)) {
-          countOfMastered += 1
+          masteredCount += 1
         }
       }
 
       return {
         name,
         masteredRate:
-          countOfShortcut === 0
+          shortcutCount === 0
             ? 0
-            : Math.floor((countOfMastered / countOfShortcut) * 100),
+            : Math.floor((masteredCount / shortcutCount) * 100),
       }
     })
   }
 
   const categoriesWithMasteredRate = (tool: string) => {
-    const toolGroup = toolGroupMap.get(tool)
+    const toolSummary = toolByNameMap.get(tool)
 
-    if (!toolGroup) {
+    if (!toolSummary) {
       return []
     }
 
-    return toolGroup.categories.map((category) => {
-      const shortcutsOfCategory = category.shortcuts.filter(
+    return toolSummary.categories.map((category) => {
+      const availableShortcutsOfCategory = category.shortcuts.filter(
         (shortcut) => !snapshot.removedIds.has(shortcut.id),
       )
-      const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
+      const masteredShortcutsOfCategory = availableShortcutsOfCategory.filter(
         (shortcut) => masteredIdSet.has(shortcut.id),
       )
 
       return {
         name: category.name,
         masteredRate:
-          shortcutsOfCategory.length === 0
+          availableShortcutsOfCategory.length === 0
             ? 0
             : Math.floor(
                 (masteredShortcutsOfCategory.length /
-                  shortcutsOfCategory.length) *
+                  availableShortcutsOfCategory.length) *
                   100,
               ),
       }

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -3,8 +3,6 @@ import type { Shortcut } from '@/types/interfaces'
 import { weight } from '@/utils/weighted-sample'
 
 export type ShortcutTrainingSessionSnapshot = {
-  tool: string
-  categories: string[]
   shortcuts: Shortcut[]
   removedIds: Set<string>
   answeredHistory: Map<string, boolean[]>

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -1,6 +1,9 @@
 import shortcutCatalog from '@/models/shortcut-catalog'
+import {
+  getCountsOfEachStatus,
+  getMasteredIds,
+} from '@/models/shortcut-training-session-status'
 import type { Shortcut } from '@/types/interfaces'
-import { weight } from '@/utils/weighted-sample'
 
 export type ShortcutTrainingSessionSnapshot = {
   shortcuts: Shortcut[]
@@ -32,66 +35,14 @@ export type ShortcutTrainingSessionSummary = {
 export const createShortcutTrainingSessionSummary = (
   snapshot: ShortcutTrainingSessionSnapshot,
 ): ShortcutTrainingSessionSummary => {
-  const shortcutsIds = () => snapshot.shortcuts.map((shortcut) => shortcut.id)
+  const countsOfEachStatus = () =>
+    getCountsOfEachStatus({
+      shortcuts: snapshot.shortcuts,
+      removedIds: snapshot.removedIds,
+      answeredHistory: snapshot.answeredHistory,
+    })
 
-  const availableIds = () =>
-    shortcutsIds().filter((id) => !snapshot.removedIds.has(id))
-
-  const answeredIds = () => Array.from(snapshot.answeredHistory.keys())
-
-  const idToWeightMap = () => {
-    const idToWeightMap = new Map<string, number>()
-
-    for (const [id, results] of snapshot.answeredHistory.entries()) {
-      if (shortcutsIds().includes(id)) {
-        idToWeightMap.set(id, weight(results))
-      }
-    }
-
-    return idToWeightMap
-  }
-
-  const masteredIds = () =>
-    [...snapshot.answeredHistory]
-      .map(([id, results]): [string, number] => [id, weight(results)])
-      .filter(([, currentWeight]) => currentWeight <= 0.6)
-      .map(([id]) => id)
-
-  const countsOfEachStatus = () => {
-    const [masteredIdsOfStatus, unmasteredIds] =
-      Array.from(idToWeightMap()).reduce<[string[], string[]]>(
-        ([masteredIds, unmasteredIds], [id, currentWeight]) =>
-          currentWeight <= 0.6
-            ? [[...masteredIds, id], unmasteredIds]
-            : [masteredIds, [...unmasteredIds, id]],
-        [[], []],
-      )
-
-    const noAnsweredIds = shortcutsIds().filter(
-      (id) => !answeredIds().includes(id),
-    )
-
-    return {
-      mastered: {
-        included: masteredIdsOfStatus.filter((id) => availableIds().includes(id))
-          .length,
-        removed: masteredIdsOfStatus.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-      unmastered: {
-        included: unmasteredIds.filter((id) => availableIds().includes(id))
-          .length,
-        removed: unmasteredIds.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-      noAnswered: {
-        included: noAnsweredIds.filter((id) => availableIds().includes(id))
-          .length,
-        removed: noAnsweredIds.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-    }
-  }
+  const masteredIds = () => getMasteredIds(snapshot)
 
   const masteredRateOfEachTool = () =>
     shortcutCatalog.tools().map((tool) => {
@@ -124,8 +75,8 @@ export const createShortcutTrainingSessionSummary = (
           shortcut.category === categoryName &&
           !snapshot.removedIds.has(shortcut.id),
       )
-      const masteredShortcutsOfCategory = shortcutsOfCategory.filter((shortcut) =>
-        masteredIdsOfTool.includes(shortcut.id),
+      const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
+        (shortcut) => masteredIdsOfTool.includes(shortcut.id),
       )
 
       return {

--- a/src/models/shortcut-training-session-summary.ts
+++ b/src/models/shortcut-training-session-summary.ts
@@ -1,0 +1,154 @@
+import shortcutCatalog from '@/models/shortcut-catalog'
+import type { Shortcut } from '@/types/interfaces'
+import { weight } from '@/utils/weighted-sample'
+
+export type ShortcutTrainingSessionSnapshot = {
+  tool: string
+  categories: string[]
+  shortcuts: Shortcut[]
+  removedIds: Set<string>
+  answeredHistory: Map<string, boolean[]>
+}
+
+type StatusCounts = {
+  included: number
+  removed: number
+}
+
+export type ShortcutTrainingSessionSummary = {
+  countsOfEachStatus: () => {
+    mastered: StatusCounts
+    unmastered: StatusCounts
+    noAnswered: StatusCounts
+  }
+  masteredRateOfEachTool: () => Array<{
+    name: string
+    masteredRate: number
+  }>
+  categoriesWithMasteredRate: (tool: string) => Array<{
+    name: string
+    masteredRate: number
+  }>
+}
+
+export const createShortcutTrainingSessionSummary = (
+  snapshot: ShortcutTrainingSessionSnapshot,
+): ShortcutTrainingSessionSummary => {
+  const shortcutsIds = () => snapshot.shortcuts.map((shortcut) => shortcut.id)
+
+  const availableIds = () =>
+    shortcutsIds().filter((id) => !snapshot.removedIds.has(id))
+
+  const answeredIds = () => Array.from(snapshot.answeredHistory.keys())
+
+  const idToWeightMap = () => {
+    const idToWeightMap = new Map<string, number>()
+
+    for (const [id, results] of snapshot.answeredHistory.entries()) {
+      if (shortcutsIds().includes(id)) {
+        idToWeightMap.set(id, weight(results))
+      }
+    }
+
+    return idToWeightMap
+  }
+
+  const masteredIds = () =>
+    [...snapshot.answeredHistory]
+      .map(([id, results]): [string, number] => [id, weight(results)])
+      .filter(([, currentWeight]) => currentWeight <= 0.6)
+      .map(([id]) => id)
+
+  const countsOfEachStatus = () => {
+    const [masteredIdsOfStatus, unmasteredIds] =
+      Array.from(idToWeightMap()).reduce<[string[], string[]]>(
+        ([masteredIds, unmasteredIds], [id, currentWeight]) =>
+          currentWeight <= 0.6
+            ? [[...masteredIds, id], unmasteredIds]
+            : [masteredIds, [...unmasteredIds, id]],
+        [[], []],
+      )
+
+    const noAnsweredIds = shortcutsIds().filter(
+      (id) => !answeredIds().includes(id),
+    )
+
+    return {
+      mastered: {
+        included: masteredIdsOfStatus.filter((id) => availableIds().includes(id))
+          .length,
+        removed: masteredIdsOfStatus.filter((id) => !availableIds().includes(id))
+          .length,
+      },
+      unmastered: {
+        included: unmasteredIds.filter((id) => availableIds().includes(id))
+          .length,
+        removed: unmasteredIds.filter((id) => !availableIds().includes(id))
+          .length,
+      },
+      noAnswered: {
+        included: noAnsweredIds.filter((id) => availableIds().includes(id))
+          .length,
+        removed: noAnsweredIds.filter((id) => !availableIds().includes(id))
+          .length,
+      },
+    }
+  }
+
+  const masteredRateOfEachTool = () =>
+    shortcutCatalog.tools().map((tool) => {
+      const shortcuts = shortcutCatalog.where({ tool })
+      const countOfShortcut = shortcuts.filter(
+        (shortcut) => !snapshot.removedIds.has(shortcut.id),
+      ).length
+      const countOfMastered = shortcuts.filter(
+        (shortcut) =>
+          masteredIds().includes(shortcut.id) &&
+          !snapshot.removedIds.has(shortcut.id),
+      ).length
+
+      return {
+        name: tool,
+        masteredRate:
+          countOfShortcut === 0
+            ? 0
+            : Math.floor((countOfMastered / countOfShortcut) * 100),
+      }
+    })
+
+  const categoriesWithMasteredRate = (tool: string) => {
+    const shortcutsOfTool = shortcutCatalog.where({ tool })
+    const masteredIdsOfTool = masteredIds()
+
+    return shortcutCatalog.categoriesOf(tool).map((categoryName) => {
+      const shortcutsOfCategory = shortcutsOfTool.filter(
+        (shortcut) =>
+          shortcut.category === categoryName &&
+          !snapshot.removedIds.has(shortcut.id),
+      )
+      const masteredShortcutsOfCategory = shortcutsOfCategory.filter((shortcut) =>
+        masteredIdsOfTool.includes(shortcut.id),
+      )
+
+      return {
+        name: categoryName,
+        masteredRate:
+          shortcutsOfCategory.length === 0
+            ? 0
+            : Math.floor(
+                (masteredShortcutsOfCategory.length /
+                  shortcutsOfCategory.length) *
+                  100,
+              ),
+      }
+    })
+  }
+
+  return {
+    countsOfEachStatus,
+    masteredRateOfEachTool,
+    categoriesWithMasteredRate,
+  }
+}
+
+export default createShortcutTrainingSessionSummary

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -435,55 +435,6 @@ export const createShortcutTrainingSession = (
     state.isListeningKeyboardEvent = true
   }
 
-  const masteredRateOfEachTool = () =>
-    shortcutCatalog.tools().map((tool) => {
-      const shortcuts = shortcutCatalog.where({ tool })
-      const countOfShortcut = shortcuts.filter(
-        (shortcut) => !state.removedIdSet.has(shortcut.id),
-      ).length
-      const masteredIds = [...state.answeredHistoryMap]
-        .map(([id, results]): [string, number] => [id, weight(results)])
-        .filter(([, currentWeight]) => currentWeight <= 0.6)
-        .map(([id]) => id)
-      const countOfMastered = shortcuts.filter(
-        (shortcut) =>
-          masteredIds.includes(shortcut.id) &&
-          !state.removedIdSet.has(shortcut.id),
-      ).length
-
-      return {
-        name: tool,
-        masteredRate: Math.floor((countOfMastered / countOfShortcut) * 100),
-      }
-    })
-
-  const categoriesWithMasteredRate = (tool: string) => {
-    const shortcutsOfTool = shortcutCatalog.where({ tool })
-    const masteredIds = [...state.answeredHistoryMap]
-      .map(([id, results]): [string, number] => [id, weight(results)])
-      .filter(([, currentWeight]) => currentWeight <= 0.6)
-      .map(([id]) => id)
-
-    return shortcutCatalog.categoriesOf(tool).map((categoryName) => {
-      const shortcutsOfCategory = shortcutsOfTool.filter(
-        (shortcut) =>
-          shortcut.category === categoryName &&
-          !state.removedIdSet.has(shortcut.id),
-      )
-      const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
-        (shortcut) => masteredIds.includes(shortcut.id),
-      )
-
-      return {
-        name: categoryName,
-        masteredRate: Math.floor(
-          (masteredShortcutsOfCategory.length / shortcutsOfCategory.length) *
-            100,
-        ),
-      }
-    })
-  }
-
   const onFullscreenchange = () => {
     state.isFullscreenMode = deps.isFullscreenMode()
     state.pressedKeyCombination.reset()
@@ -507,10 +458,8 @@ export const createShortcutTrainingSession = (
     judge,
     restoreRemovedShortcuts,
     selectToolAndCategories,
-    masteredRateOfEachTool,
     exitSelectionOfToolAndCategories,
     onFullscreenchange,
-    categoriesWithMasteredRate,
   }
 }
 

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -106,21 +106,8 @@ const defaultSessionDeps: ShortcutTrainingSessionDeps = {
 export const createShortcutTrainingSession = (
   state: ShortcutTrainingState,
   deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
+  catalogSummary: ShortcutCatalogSummary,
 ) => {
-  const catalogSummary: ShortcutCatalogSummary = {
-    tools: shortcutCatalog.tools().map((tool) => ({
-      name: tool,
-      shortcuts: shortcutCatalog.where({ tool }),
-      categories: shortcutCatalog.categoriesOf(tool).map((categoryName) => ({
-        name: categoryName,
-        shortcuts: shortcutCatalog.where({
-          tool,
-          categories: [categoryName],
-        }),
-      })),
-    })),
-  }
-
   const correctKeyCombinations = () =>
     new KeyCombinations(
       state.shortcut.keyCombinations.map(

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -2,17 +2,10 @@ import { Shortcut, KeyCombinable } from '@/types/interfaces'
 import KeyCombination from '@/models/key-combination'
 import KeyCombinations from '@/models/key-combinations'
 import Keyboard from '@/utils/keyboard'
-import LocalStorage from '@/utils/local-storage'
 import sample from '@/utils/sample'
 import shortcutCatalog from '@/models/shortcut-catalog'
-import toggleFullscreen from '@/utils/toggle-fullscreen'
 import { weight, weightedSampleKey } from '@/utils/weighted-sample'
-import {
-  ANSWERED_HISTORY_KEY,
-  REMOVED_IDS_KEY,
-  SELECTED_CATEGORIES_KEY,
-  SELECTED_TOOL_KEY,
-} from '@/constants/local-storage-keys'
+import toggleFullscreen from '@/utils/toggle-fullscreen'
 
 export type ShortcutTrainingState = {
   tool: string
@@ -36,6 +29,18 @@ export type ShortcutTrainingState = {
   answeredHistoryMap: Map<string, boolean[]>
 }
 
+export type ShortcutTrainingSessionDeps = {
+  isFullscreenMode: () => boolean
+  sample: typeof sample
+  weightedSampleKey: typeof weightedSampleKey
+  scheduleRestartTyping: (callback: () => void) => void
+  toggleFullscreen: () => void
+  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => void
+  persistRemovedIds: (removedIds: string[]) => void
+  persistSelectedTool: (tool: string) => void
+  persistSelectedCategories: (categories: string[]) => void
+}
+
 export const createShortcutTrainingState = ({
   tool,
   categories,
@@ -43,6 +48,7 @@ export const createShortcutTrainingState = ({
   shortcut,
   removedIds,
   answeredHistory,
+  isFullscreenMode,
 }: {
   tool: string
   categories: string[]
@@ -50,6 +56,7 @@ export const createShortcutTrainingState = ({
   shortcut: Shortcut
   removedIds: string[]
   answeredHistory: Record<string, boolean[]>
+  isFullscreenMode: boolean
 }): ShortcutTrainingState => ({
   tool,
   categories: new Set(categories),
@@ -65,25 +72,39 @@ export const createShortcutTrainingState = ({
   isMarkedSelfAsCorrect: false,
   isMarkedSelfAsWrong: false,
   isShakingKeyCombinationView: false,
-  isFullscreenMode:
-    !!document.fullscreenElement && document.fullscreenElement !== null,
+  isFullscreenMode,
 
   pressedKeyCombination: new KeyCombination(),
   removedIdSet: new Set<string>(removedIds),
   answeredHistoryMap: new Map<string, boolean[]>(
-    Object.entries(answeredHistory)
+    Object.entries(answeredHistory),
   ),
 })
 
-const TimeIntervalToRestartTyping =
-  import.meta.env.MODE === 'test' ? 0 : 1000
+const defaultSessionDeps: ShortcutTrainingSessionDeps = {
+  isFullscreenMode: () =>
+    !!document.fullscreenElement && document.fullscreenElement !== null,
+  sample,
+  weightedSampleKey,
+  scheduleRestartTyping: (callback) => {
+    setTimeout(callback, import.meta.env.MODE === 'test' ? 0 : 1000)
+  },
+  toggleFullscreen,
+  persistAnsweredHistory: () => undefined,
+  persistRemovedIds: () => undefined,
+  persistSelectedTool: () => undefined,
+  persistSelectedCategories: () => undefined,
+}
 
-export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
+export const createShortcutTrainingSession = (
+  state: ShortcutTrainingState,
+  deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
+) => {
   const correctKeyCombinations = () =>
     new KeyCombinations(
       state.shortcut.keyCombinations.map(
-        (keyCombination) => new KeyCombination(keyCombination)
-      )
+        (keyCombination) => new KeyCombination(keyCombination),
+      ),
     )
 
   const shortcutsIds = () => state.shortcuts.map((shortcut) => shortcut.id)
@@ -128,17 +149,19 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
         currentWeight <= 0.6
           ? [[...masteredIds, id], unmasteredIds]
           : [masteredIds, [...unmasteredIds, id]],
-      [[], []]
+      [[], []],
     )
 
     const noAnsweredIds = shortcutsIds().filter(
-      (id) => !answeredIds().includes(id)
+      (id) => !answeredIds().includes(id),
     )
 
     return {
       mastered: {
-        included: masteredIds.filter((id) => availableIds().includes(id)).length,
-        removed: masteredIds.filter((id) => !availableIds().includes(id)).length,
+        included: masteredIds.filter((id) => availableIds().includes(id))
+          .length,
+        removed: masteredIds.filter((id) => !availableIds().includes(id))
+          .length,
       },
       unmastered: {
         included: unmasteredIds.filter((id) => availableIds().includes(id))
@@ -157,7 +180,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
 
   const wordsOfDescriptionFilledByCorrectKeys = () =>
     Keyboard.splitByKeyDescription(state.shortcut.keysDescription).map(
-      (word) => Keyboard.keyOfKeyDescription(word) ?? word
+      (word) => Keyboard.keyOfKeyDescription(word) ?? word,
     )
 
   const wordsOfDescriptionFilledByPressedKeys = () => {
@@ -184,14 +207,16 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
 
   const nextShortcut = () => {
     if (noAnsweredAvailableIds().length === 0) {
-      const nextId = weightedSampleKey(availableIdToWeightMap())
+      const nextId = deps.weightedSampleKey(availableIdToWeightMap())
 
-      return state.shortcuts.find((shortcut) => shortcut.id === nextId) as Shortcut
+      return state.shortcuts.find(
+        (shortcut) => shortcut.id === nextId,
+      ) as Shortcut
     }
 
     if (noAnsweredAvailableIds().length === 1) {
       return state.shortcuts.find(
-        (shortcut) => shortcut.id === noAnsweredAvailableIds()[0]
+        (shortcut) => shortcut.id === noAnsweredAvailableIds()[0],
       ) as Shortcut
     }
 
@@ -199,7 +224,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
       .filter((shortcut) => noAnsweredAvailableIds().includes(shortcut.id))
       .filter((shortcut) => shortcut.id !== state.shortcut.id)
 
-    return sample(noAnsweredAvailableShortcuts)
+    return deps.sample(noAnsweredAvailableShortcuts)
   }
 
   const resetTypingState = () => {
@@ -220,10 +245,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
       state.answeredHistoryMap.set(id, [result])
     }
 
-    LocalStorage.set(
-      ANSWERED_HISTORY_KEY,
-      Object.fromEntries(state.answeredHistoryMap)
-    )
+    deps.persistAnsweredHistory(Object.fromEntries(state.answeredHistoryMap))
   }
 
   const respondToSelectToolsKey = () => {
@@ -241,13 +263,13 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     state.isListeningKeyboardEvent = false
     state.isRemoveKeyPressed = true
     state.removedIdSet.add(state.shortcut.id)
-    LocalStorage.set(REMOVED_IDS_KEY, [...state.removedIdSet])
+    deps.persistRemovedIds([...state.removedIdSet])
 
-    setTimeout(() => {
+    deps.scheduleRestartTyping(() => {
       state.shortcut = nextShortcut()
       resetTypingState()
       state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
+    })
   }
 
   const respondToCorrectKey = () => {
@@ -256,11 +278,11 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
 
     if (!state.isWrongKeyPressed) saveResult(state.shortcut.id, true)
 
-    setTimeout(() => {
+    deps.scheduleRestartTyping(() => {
       state.shortcut = nextShortcut()
       resetTypingState()
       state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
+    })
   }
 
   const respondToWrongKey = () => {
@@ -269,11 +291,11 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     state.isShakingKeyCombinationView = true
     saveResult(state.shortcut.id, false)
 
-    setTimeout(() => {
+    deps.scheduleRestartTyping(() => {
       state.isListeningKeyboardEvent = true
       state.isShakingKeyCombinationView = false
       state.pressedKeyCombination.reset()
-    }, TimeIntervalToRestartTyping)
+    })
   }
 
   const respondToMarkSelfAsCorrectKey = () => {
@@ -281,11 +303,11 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     state.isMarkedSelfAsCorrect = true
     saveResult(state.shortcut.id, true)
 
-    setTimeout(() => {
+    deps.scheduleRestartTyping(() => {
       state.shortcut = nextShortcut()
       resetTypingState()
       state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
+    })
   }
 
   const respondToMarkSelfAsWrongKey = () => {
@@ -293,11 +315,11 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     state.isMarkedSelfAsWrong = true
     saveResult(state.shortcut.id, false)
 
-    setTimeout(() => {
+    deps.scheduleRestartTyping(() => {
       state.shortcut = nextShortcut()
       resetTypingState()
       state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
+    })
   }
 
   const judge = () => {
@@ -329,7 +351,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     }
 
     if (state.pressedKeyCombination.isToggleFullscreenKey()) {
-      toggleFullscreen()
+      deps.toggleFullscreen()
       return
     }
 
@@ -378,10 +400,10 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
   const restoreRemovedShortcuts = () => {
     if (
       confirm(
-        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？'
+        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？',
       )
     ) {
-      LocalStorage.remove(REMOVED_IDS_KEY)
+      deps.persistRemovedIds([])
       state.removedIdSet = new Set<string>()
       resetTypingState()
       state.shortcut = state.shortcuts[0]
@@ -390,10 +412,10 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
 
   const selectToolAndCategories = (tool: string, categories: string[]) => {
     state.tool = tool
-    LocalStorage.set(SELECTED_TOOL_KEY, tool)
+    deps.persistSelectedTool(tool)
 
     state.categories = new Set(categories)
-    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
+    deps.persistSelectedCategories(categories)
 
     state.shortcuts = shortcutCatalog.where({
       tool,
@@ -401,8 +423,9 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     })
 
     state.shortcut =
-      state.shortcuts.find((shortcut) => !state.removedIdSet.has(shortcut.id)) ??
-      state.shortcuts[0]
+      state.shortcuts.find(
+        (shortcut) => !state.removedIdSet.has(shortcut.id),
+      ) ?? state.shortcuts[0]
 
     exitSelectionOfToolAndCategories()
   }
@@ -416,7 +439,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
     shortcutCatalog.tools().map((tool) => {
       const shortcuts = shortcutCatalog.where({ tool })
       const countOfShortcut = shortcuts.filter(
-        (shortcut) => !state.removedIdSet.has(shortcut.id)
+        (shortcut) => !state.removedIdSet.has(shortcut.id),
       ).length
       const masteredIds = [...state.answeredHistoryMap]
         .map(([id, results]): [string, number] => [id, weight(results)])
@@ -425,7 +448,7 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
       const countOfMastered = shortcuts.filter(
         (shortcut) =>
           masteredIds.includes(shortcut.id) &&
-          !state.removedIdSet.has(shortcut.id)
+          !state.removedIdSet.has(shortcut.id),
       ).length
 
       return {
@@ -445,23 +468,24 @@ export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
       const shortcutsOfCategory = shortcutsOfTool.filter(
         (shortcut) =>
           shortcut.category === categoryName &&
-          !state.removedIdSet.has(shortcut.id)
+          !state.removedIdSet.has(shortcut.id),
       )
-      const masteredShortcutsOfCategory = shortcutsOfCategory.filter((shortcut) =>
-        masteredIds.includes(shortcut.id)
+      const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
+        (shortcut) => masteredIds.includes(shortcut.id),
       )
 
       return {
         name: categoryName,
         masteredRate: Math.floor(
-          (masteredShortcutsOfCategory.length / shortcutsOfCategory.length) * 100
+          (masteredShortcutsOfCategory.length / shortcutsOfCategory.length) *
+            100,
         ),
       }
     })
   }
 
   const onFullscreenchange = () => {
-    state.isFullscreenMode = !!document.fullscreenElement
+    state.isFullscreenMode = deps.isFullscreenMode()
     state.pressedKeyCombination.reset()
   }
 

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -5,7 +5,9 @@ import {
   getAvailableIdToWeightMap,
   getCountsOfEachStatus,
 } from '@/models/shortcut-training-session-status'
-import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
+import createShortcutTrainingSessionSummary, {
+  type ShortcutCatalogSummary,
+} from '@/models/shortcut-training-session-summary'
 import type { KeyCombinable, Shortcut } from '@/types/interfaces'
 import Keyboard from '@/utils/keyboard'
 import sample from '@/utils/sample'
@@ -105,6 +107,20 @@ export const createShortcutTrainingSession = (
   state: ShortcutTrainingState,
   deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
 ) => {
+  const catalogSummary: ShortcutCatalogSummary = {
+    tools: shortcutCatalog.tools().map((tool) => ({
+      name: tool,
+      shortcuts: shortcutCatalog.where({ tool }),
+      categories: shortcutCatalog.categoriesOf(tool).map((categoryName) => ({
+        name: categoryName,
+        shortcuts: shortcutCatalog.where({
+          tool,
+          categories: [categoryName],
+        }),
+      })),
+    })),
+  }
+
   const correctKeyCombinations = () =>
     new KeyCombinations(
       state.shortcut.keyCombinations.map(
@@ -139,11 +155,14 @@ export const createShortcutTrainingSession = (
   }
 
   const createSummary = () =>
-    createShortcutTrainingSessionSummary({
-      shortcuts: state.shortcuts,
-      removedIds: new Set(state.removedIdSet),
-      answeredHistory: new Map(state.answeredHistoryMap),
-    })
+    createShortcutTrainingSessionSummary(
+      {
+        shortcuts: state.shortcuts,
+        removedIds: new Set(state.removedIdSet),
+        answeredHistory: new Map(state.answeredHistoryMap),
+      },
+      catalogSummary,
+    )
 
   const wordsOfDescriptionFilledByCorrectKeys = () =>
     Keyboard.splitByKeyDescription(state.shortcut.keysDescription).map(

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -1,3 +1,4 @@
+import { createEmptyShortcut } from '@/models/empty-shortcut'
 import KeyCombination from '@/models/key-combination'
 import KeyCombinations from '@/models/key-combinations'
 import shortcutCatalog from '@/models/shortcut-catalog'
@@ -14,19 +15,6 @@ import Keyboard from '@/utils/keyboard'
 import sample from '@/utils/sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
 import { weightedSampleKey } from '@/utils/weighted-sample'
-
-const createEmptyShortcut = (): Shortcut => ({
-  id: '',
-  app: '',
-  os: '',
-  category: '',
-  action: '',
-  keysDescription: '',
-  keyCombinations: [],
-  isAvailable: false,
-  unavailableReason: null,
-  needsFillInBlankMode: false,
-})
 
 export type ShortcutTrainingState = {
   tool: string
@@ -120,12 +108,24 @@ export const createShortcutTrainingSession = (
   catalogSummary: ShortcutCatalogSummary,
   deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
 ) => {
-  const correctKeyCombinations = () =>
-    new KeyCombinations(
-      state.shortcut.keyCombinations.map(
-        (keyCombination) => new KeyCombination(keyCombination),
-      ),
-    )
+  let cachedShortcutId: string | undefined
+  let cachedCorrectKeyCombinations: KeyCombinations | undefined
+
+  const correctKeyCombinations = () => {
+    if (
+      cachedShortcutId !== state.shortcut.id ||
+      !cachedCorrectKeyCombinations
+    ) {
+      cachedShortcutId = state.shortcut.id
+      cachedCorrectKeyCombinations = new KeyCombinations(
+        state.shortcut.keyCombinations.map(
+          (keyCombination) => new KeyCombination(keyCombination),
+        ),
+      )
+    }
+
+    return cachedCorrectKeyCombinations
+  }
 
   const shortcutIds = () => state.shortcuts.map((shortcut) => shortcut.id)
 

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -8,6 +8,7 @@ import {
 import createShortcutTrainingSessionSummary, {
   type ShortcutCatalogSummary,
 } from '@/models/shortcut-training-session-summary'
+import { createShortcutTrainingSessionEffects } from '@/models/shortcut-training-session-effects'
 import type { KeyCombinable, Shortcut } from '@/types/interfaces'
 import Keyboard from '@/utils/keyboard'
 import sample from '@/utils/sample'
@@ -209,89 +210,12 @@ export const createShortcutTrainingSession = (
     state.pressedKeyCombination.reset()
   }
 
-  const saveResult = (id: string, result: boolean) => {
-    if (state.answeredHistoryMap.has(id)) {
-      state.answeredHistoryMap.get(id)?.push(result)
-    } else {
-      state.answeredHistoryMap.set(id, [result])
-    }
-
-    deps.persistAnsweredHistory(state.answeredHistoryMap)
-  }
-
-  const respondToSelectToolsKey = () => {
-    resetTypingState()
-    state.isListeningKeyboardEvent = false
-    state.isSelectToolsKeyPressed = true
-  }
-
-  const respondToShowCorrectKey = () => {
-    resetTypingState()
-    state.isShowCorrectKeyPressed = true
-  }
-
-  const respondToRemoveKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isRemoveKeyPressed = true
-    state.removedIdSet.add(state.shortcut.id)
-    deps.persistRemovedIds(state.removedIdSet)
-
-    deps.scheduleRestartTyping(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    })
-  }
-
-  const respondToCorrectKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isCorrectKeyPressed = true
-
-    if (!state.isWrongKeyPressed) saveResult(state.shortcut.id, true)
-
-    deps.scheduleRestartTyping(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    })
-  }
-
-  const respondToWrongKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isWrongKeyPressed = true
-    state.isShakingKeyCombinationView = true
-    saveResult(state.shortcut.id, false)
-
-    deps.scheduleRestartTyping(() => {
-      state.isListeningKeyboardEvent = true
-      state.isShakingKeyCombinationView = false
-      state.pressedKeyCombination.reset()
-    })
-  }
-
-  const respondToMarkSelfAsCorrectKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isMarkedSelfAsCorrect = true
-    saveResult(state.shortcut.id, true)
-
-    deps.scheduleRestartTyping(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    })
-  }
-
-  const respondToMarkSelfAsWrongKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isMarkedSelfAsWrong = true
-    saveResult(state.shortcut.id, false)
-
-    deps.scheduleRestartTyping(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    })
-  }
+  const effects = createShortcutTrainingSessionEffects(
+    state,
+    deps,
+    nextShortcut,
+    resetTypingState,
+  )
 
   const judge = () => {
     if (!state.pressedKeyCombination.hasPressedSomeKey()) return
@@ -312,45 +236,45 @@ export const createShortcutTrainingSession = (
     }
 
     if (state.pressedKeyCombination.isRemoveKey()) {
-      respondToRemoveKey()
+      effects.respondToRemoveKey()
       return
     }
 
     if (state.pressedKeyCombination.isSelectToolsKey()) {
-      respondToSelectToolsKey()
+      effects.respondToSelectToolsKey()
       return
     }
 
     if (state.pressedKeyCombination.isToggleFullscreenKey()) {
-      deps.toggleFullscreen()
+      effects.toggleFullscreen()
       return
     }
 
     if (state.shortcut.isAvailable && !needsFullscreenMode()) {
       if (correctKeyCombinations().has(state.pressedKeyCombination)) {
-        respondToCorrectKey()
+        effects.respondToCorrectKey()
       } else if (
         !state.isWrongKeyPressed &&
         !state.pressedKeyCombination.isModifierKey()
       ) {
-        respondToWrongKey()
+        effects.respondToWrongKey()
       }
     } else {
       if (
         !state.isShowCorrectKeyPressed &&
         state.pressedKeyCombination.isShowCorrectKey()
       ) {
-        respondToShowCorrectKey()
+        effects.respondToShowCorrectKey()
       } else if (
         state.isShowCorrectKeyPressed &&
         state.pressedKeyCombination.isMarkedSelfAsCorrectKey()
       ) {
-        respondToMarkSelfAsCorrectKey()
+        effects.respondToMarkSelfAsCorrectKey()
       } else if (
         state.isShowCorrectKeyPressed &&
         state.pressedKeyCombination.isMarkedSelfAsWrongKey()
       ) {
-        respondToMarkSelfAsWrongKey()
+        effects.respondToMarkSelfAsWrongKey()
       }
     }
   }
@@ -369,24 +293,11 @@ export const createShortcutTrainingSession = (
   }
 
   const restoreRemovedShortcuts = () => {
-    if (
-      confirm(
-        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？',
-      )
-    ) {
-      deps.persistRemovedIds(new Set())
-      state.removedIdSet = new Set<string>()
-      resetTypingState()
-      state.shortcut = state.shortcuts[0]
-    }
+    effects.restoreRemovedShortcuts()
   }
 
   const selectToolAndCategories = (tool: string, categories: string[]) => {
-    state.tool = tool
-    deps.persistSelectedTool(tool)
-
-    state.categories = new Set(categories)
-    deps.persistSelectedCategories(categories)
+    effects.selectToolAndCategories(tool, categories)
 
     state.shortcuts = shortcutCatalog.where({
       tool,

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -1,6 +1,7 @@
 import KeyCombination from '@/models/key-combination'
 import KeyCombinations from '@/models/key-combinations'
 import shortcutCatalog from '@/models/shortcut-catalog'
+import { createShortcutTrainingSessionEffects } from '@/models/shortcut-training-session-effects'
 import {
   getAvailableIdToWeightMap,
   getCountsOfEachStatus,
@@ -8,7 +9,6 @@ import {
 import createShortcutTrainingSessionSummary, {
   type ShortcutCatalogSummary,
 } from '@/models/shortcut-training-session-summary'
-import { createShortcutTrainingSessionEffects } from '@/models/shortcut-training-session-effects'
 import type { KeyCombinable, Shortcut } from '@/types/interfaces'
 import Keyboard from '@/utils/keyboard'
 import sample from '@/utils/sample'
@@ -119,10 +119,10 @@ export const createShortcutTrainingSession = (
   const availableIds = () =>
     shortcutsIds().filter((id) => !state.removedIdSet.has(id))
 
-  const answeredIds = () => Array.from(state.answeredHistoryMap.keys())
+  const answeredIdSet = () => new Set(state.answeredHistoryMap.keys())
 
   const noAnsweredAvailableIds = () =>
-    availableIds().filter((id) => !answeredIds().includes(id))
+    availableIds().filter((id) => !answeredIdSet().has(id))
 
   const availableIdToWeightMap = () => {
     return getAvailableIdToWeightMap({
@@ -178,22 +178,25 @@ export const createShortcutTrainingSession = (
     state.shortcuts.every((shortcut) => state.removedIdSet.has(shortcut.id))
 
   const nextShortcut = () => {
-    if (noAnsweredAvailableIds().length === 0) {
+    const noAnsweredAvailableIdList = noAnsweredAvailableIds()
+    const noAnsweredAvailableIdSet = new Set(noAnsweredAvailableIdList)
+    const shortcutByIdMap = new Map(
+      state.shortcuts.map((shortcut) => [shortcut.id, shortcut] as const),
+    )
+
+    if (noAnsweredAvailableIdList.length === 0) {
       const nextId = deps.weightedSampleKey(availableIdToWeightMap())
 
-      return state.shortcuts.find(
-        (shortcut) => shortcut.id === nextId,
-      ) as Shortcut
+      return (shortcutByIdMap.get(nextId) ?? state.shortcuts[0]) as Shortcut
     }
 
-    if (noAnsweredAvailableIds().length === 1) {
-      return state.shortcuts.find(
-        (shortcut) => shortcut.id === noAnsweredAvailableIds()[0],
-      ) as Shortcut
+    if (noAnsweredAvailableIdList.length === 1) {
+      return (shortcutByIdMap.get(noAnsweredAvailableIdList[0]) ??
+        state.shortcuts[0]) as Shortcut
     }
 
     const noAnsweredAvailableShortcuts = state.shortcuts
-      .filter((shortcut) => noAnsweredAvailableIds().includes(shortcut.id))
+      .filter((shortcut) => noAnsweredAvailableIdSet.has(shortcut.id))
       .filter((shortcut) => shortcut.id !== state.shortcut.id)
 
     return deps.sample(noAnsweredAvailableShortcuts)
@@ -299,7 +302,7 @@ export const createShortcutTrainingSession = (
   const selectToolAndCategories = (tool: string, categories: string[]) => {
     effects.selectToolAndCategories(tool, categories)
 
-    state.shortcuts = shortcutCatalog.where({
+    state.shortcuts = shortcutCatalog.searchShortcuts({
       tool,
       categories,
     })
@@ -329,7 +332,6 @@ export const createShortcutTrainingSession = (
   return {
     correctKeyCombinations,
     availableIds,
-    answeredIds,
     noAnsweredAvailableIds,
     availableIdToWeightMap,
     countsOfEachStatus,

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -1,0 +1,493 @@
+import { Shortcut, KeyCombinable } from '@/types/interfaces'
+import KeyCombination from '@/models/key-combination'
+import KeyCombinations from '@/models/key-combinations'
+import Keyboard from '@/utils/keyboard'
+import LocalStorage from '@/utils/local-storage'
+import sample from '@/utils/sample'
+import shortcutCatalog from '@/models/shortcut-catalog'
+import toggleFullscreen from '@/utils/toggle-fullscreen'
+import { weight, weightedSampleKey } from '@/utils/weighted-sample'
+import {
+  ANSWERED_HISTORY_KEY,
+  REMOVED_IDS_KEY,
+  SELECTED_CATEGORIES_KEY,
+  SELECTED_TOOL_KEY,
+} from '@/constants/local-storage-keys'
+
+export type ShortcutTrainingState = {
+  tool: string
+  categories: Set<string>
+  shortcuts: Shortcut[]
+  shortcut: Shortcut
+
+  isListeningKeyboardEvent: boolean
+  isCorrectKeyPressed: boolean
+  isWrongKeyPressed: boolean
+  isRemoveKeyPressed: boolean
+  isSelectToolsKeyPressed: boolean
+  isShowCorrectKeyPressed: boolean
+  isMarkedSelfAsCorrect: boolean
+  isMarkedSelfAsWrong: boolean
+  isShakingKeyCombinationView: boolean
+  isFullscreenMode: boolean
+
+  pressedKeyCombination: KeyCombination
+  removedIdSet: Set<string>
+  answeredHistoryMap: Map<string, boolean[]>
+}
+
+export const createShortcutTrainingState = ({
+  tool,
+  categories,
+  shortcuts,
+  shortcut,
+  removedIds,
+  answeredHistory,
+}: {
+  tool: string
+  categories: string[]
+  shortcuts: Shortcut[]
+  shortcut: Shortcut
+  removedIds: string[]
+  answeredHistory: Record<string, boolean[]>
+}): ShortcutTrainingState => ({
+  tool,
+  categories: new Set(categories),
+  shortcuts,
+  shortcut,
+
+  isListeningKeyboardEvent: true,
+  isCorrectKeyPressed: false,
+  isWrongKeyPressed: false,
+  isRemoveKeyPressed: false,
+  isSelectToolsKeyPressed: false,
+  isShowCorrectKeyPressed: false,
+  isMarkedSelfAsCorrect: false,
+  isMarkedSelfAsWrong: false,
+  isShakingKeyCombinationView: false,
+  isFullscreenMode:
+    !!document.fullscreenElement && document.fullscreenElement !== null,
+
+  pressedKeyCombination: new KeyCombination(),
+  removedIdSet: new Set<string>(removedIds),
+  answeredHistoryMap: new Map<string, boolean[]>(
+    Object.entries(answeredHistory)
+  ),
+})
+
+const TimeIntervalToRestartTyping =
+  import.meta.env.MODE === 'test' ? 0 : 1000
+
+export const createShortcutTrainingSession = (state: ShortcutTrainingState) => {
+  const correctKeyCombinations = () =>
+    new KeyCombinations(
+      state.shortcut.keyCombinations.map(
+        (keyCombination) => new KeyCombination(keyCombination)
+      )
+    )
+
+  const shortcutsIds = () => state.shortcuts.map((shortcut) => shortcut.id)
+
+  const availableIds = () =>
+    shortcutsIds().filter((id) => !state.removedIdSet.has(id))
+
+  const answeredIds = () => Array.from(state.answeredHistoryMap.keys())
+
+  const noAnsweredAvailableIds = () =>
+    availableIds().filter((id) => !answeredIds().includes(id))
+
+  const idToWeightMap = () => {
+    const idToWeightMap = new Map<string, number>()
+
+    for (const [id, results] of state.answeredHistoryMap.entries()) {
+      if (shortcutsIds().includes(id)) {
+        idToWeightMap.set(id, weight(results))
+      }
+    }
+
+    return idToWeightMap
+  }
+
+  const availableIdToWeightMap = () => {
+    const availableIdToWeightMap = new Map<string, number>()
+
+    for (const [id, currentWeight] of idToWeightMap().entries()) {
+      if (availableIds().includes(id)) {
+        availableIdToWeightMap.set(id, currentWeight)
+      }
+    }
+
+    return availableIdToWeightMap
+  }
+
+  const countsOfEachStatus = () => {
+    const [masteredIds, unmasteredIds] = Array.from(idToWeightMap()).reduce<
+      [string[], string[]]
+    >(
+      ([masteredIds, unmasteredIds], [id, currentWeight]) =>
+        currentWeight <= 0.6
+          ? [[...masteredIds, id], unmasteredIds]
+          : [masteredIds, [...unmasteredIds, id]],
+      [[], []]
+    )
+
+    const noAnsweredIds = shortcutsIds().filter(
+      (id) => !answeredIds().includes(id)
+    )
+
+    return {
+      mastered: {
+        included: masteredIds.filter((id) => availableIds().includes(id)).length,
+        removed: masteredIds.filter((id) => !availableIds().includes(id)).length,
+      },
+      unmastered: {
+        included: unmasteredIds.filter((id) => availableIds().includes(id))
+          .length,
+        removed: unmasteredIds.filter((id) => !availableIds().includes(id))
+          .length,
+      },
+      noAnswered: {
+        included: noAnsweredIds.filter((id) => availableIds().includes(id))
+          .length,
+        removed: noAnsweredIds.filter((id) => !availableIds().includes(id))
+          .length,
+      },
+    }
+  }
+
+  const wordsOfDescriptionFilledByCorrectKeys = () =>
+    Keyboard.splitByKeyDescription(state.shortcut.keysDescription).map(
+      (word) => Keyboard.keyOfKeyDescription(word) ?? word
+    )
+
+  const wordsOfDescriptionFilledByPressedKeys = () => {
+    const pressedKeys = state.pressedKeyCombination.keys()
+
+    return Keyboard.splitByKeyDescription(state.shortcut.keysDescription)
+      .map((word) => Keyboard.keyOfKeyDescription(word) ?? word)
+      .map((word) => {
+        if (Keyboard.isKey(word) && !Keyboard.isUndetectableKey(word)) {
+          return pressedKeys.shift() ?? ''
+        }
+
+        return word
+      })
+  }
+
+  const needsFullscreenMode = () =>
+    correctKeyCombinations().hasOnlyAvailableInFullscreen() &&
+    !state.isFullscreenMode
+
+  const removedShortcutExists = () => state.removedIdSet.size > 0
+  const isRemovedAll = () =>
+    state.shortcuts.every((shortcut) => state.removedIdSet.has(shortcut.id))
+
+  const nextShortcut = () => {
+    if (noAnsweredAvailableIds().length === 0) {
+      const nextId = weightedSampleKey(availableIdToWeightMap())
+
+      return state.shortcuts.find((shortcut) => shortcut.id === nextId) as Shortcut
+    }
+
+    if (noAnsweredAvailableIds().length === 1) {
+      return state.shortcuts.find(
+        (shortcut) => shortcut.id === noAnsweredAvailableIds()[0]
+      ) as Shortcut
+    }
+
+    const noAnsweredAvailableShortcuts = state.shortcuts
+      .filter((shortcut) => noAnsweredAvailableIds().includes(shortcut.id))
+      .filter((shortcut) => shortcut.id !== state.shortcut.id)
+
+    return sample(noAnsweredAvailableShortcuts)
+  }
+
+  const resetTypingState = () => {
+    state.isRemoveKeyPressed = false
+    state.isCorrectKeyPressed = false
+    state.isWrongKeyPressed = false
+    state.isSelectToolsKeyPressed = false
+    state.isShowCorrectKeyPressed = false
+    state.isMarkedSelfAsCorrect = false
+    state.isMarkedSelfAsWrong = false
+    state.pressedKeyCombination.reset()
+  }
+
+  const saveResult = (id: string, result: boolean) => {
+    if (state.answeredHistoryMap.has(id)) {
+      state.answeredHistoryMap.get(id)?.push(result)
+    } else {
+      state.answeredHistoryMap.set(id, [result])
+    }
+
+    LocalStorage.set(
+      ANSWERED_HISTORY_KEY,
+      Object.fromEntries(state.answeredHistoryMap)
+    )
+  }
+
+  const respondToSelectToolsKey = () => {
+    resetTypingState()
+    state.isListeningKeyboardEvent = false
+    state.isSelectToolsKeyPressed = true
+  }
+
+  const respondToShowCorrectKey = () => {
+    resetTypingState()
+    state.isShowCorrectKeyPressed = true
+  }
+
+  const respondToRemoveKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isRemoveKeyPressed = true
+    state.removedIdSet.add(state.shortcut.id)
+    LocalStorage.set(REMOVED_IDS_KEY, [...state.removedIdSet])
+
+    setTimeout(() => {
+      state.shortcut = nextShortcut()
+      resetTypingState()
+      state.isListeningKeyboardEvent = true
+    }, TimeIntervalToRestartTyping)
+  }
+
+  const respondToCorrectKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isCorrectKeyPressed = true
+
+    if (!state.isWrongKeyPressed) saveResult(state.shortcut.id, true)
+
+    setTimeout(() => {
+      state.shortcut = nextShortcut()
+      resetTypingState()
+      state.isListeningKeyboardEvent = true
+    }, TimeIntervalToRestartTyping)
+  }
+
+  const respondToWrongKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isWrongKeyPressed = true
+    state.isShakingKeyCombinationView = true
+    saveResult(state.shortcut.id, false)
+
+    setTimeout(() => {
+      state.isListeningKeyboardEvent = true
+      state.isShakingKeyCombinationView = false
+      state.pressedKeyCombination.reset()
+    }, TimeIntervalToRestartTyping)
+  }
+
+  const respondToMarkSelfAsCorrectKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isMarkedSelfAsCorrect = true
+    saveResult(state.shortcut.id, true)
+
+    setTimeout(() => {
+      state.shortcut = nextShortcut()
+      resetTypingState()
+      state.isListeningKeyboardEvent = true
+    }, TimeIntervalToRestartTyping)
+  }
+
+  const respondToMarkSelfAsWrongKey = () => {
+    state.isListeningKeyboardEvent = false
+    state.isMarkedSelfAsWrong = true
+    saveResult(state.shortcut.id, false)
+
+    setTimeout(() => {
+      state.shortcut = nextShortcut()
+      resetTypingState()
+      state.isListeningKeyboardEvent = true
+    }, TimeIntervalToRestartTyping)
+  }
+
+  const judge = () => {
+    if (!state.pressedKeyCombination.hasPressedSomeKey()) return
+    if (
+      state.pressedKeyCombination.isModifierKey() &&
+      !correctKeyCombinations().hasOnlyModifierKeys()
+    ) {
+      return
+    }
+
+    if (
+      state.pressedKeyCombination.isOnlyEnterKey() &&
+      !correctKeyCombinations().hasOnlyEnterKey()
+    ) {
+      state.shortcut = nextShortcut()
+      resetTypingState()
+      return
+    }
+
+    if (state.pressedKeyCombination.isRemoveKey()) {
+      respondToRemoveKey()
+      return
+    }
+
+    if (state.pressedKeyCombination.isSelectToolsKey()) {
+      respondToSelectToolsKey()
+      return
+    }
+
+    if (state.pressedKeyCombination.isToggleFullscreenKey()) {
+      toggleFullscreen()
+      return
+    }
+
+    if (state.shortcut.isAvailable && !needsFullscreenMode()) {
+      if (correctKeyCombinations().has(state.pressedKeyCombination)) {
+        respondToCorrectKey()
+      } else if (
+        !state.isWrongKeyPressed &&
+        !state.pressedKeyCombination.isModifierKey()
+      ) {
+        respondToWrongKey()
+      }
+    } else {
+      if (
+        !state.isShowCorrectKeyPressed &&
+        state.pressedKeyCombination.isShowCorrectKey()
+      ) {
+        respondToShowCorrectKey()
+      } else if (
+        state.isShowCorrectKeyPressed &&
+        state.pressedKeyCombination.isMarkedSelfAsCorrectKey()
+      ) {
+        respondToMarkSelfAsCorrectKey()
+      } else if (
+        state.isShowCorrectKeyPressed &&
+        state.pressedKeyCombination.isMarkedSelfAsWrongKey()
+      ) {
+        respondToMarkSelfAsWrongKey()
+      }
+    }
+  }
+
+  const keyDown = (keyCombinable: KeyCombinable) => {
+    if (isRemovedAll() || !state.isListeningKeyboardEvent) return
+
+    state.pressedKeyCombination.keyDown(keyCombinable)
+    judge()
+  }
+
+  const keyUp = (key: string) => {
+    if (isRemovedAll() || !state.isListeningKeyboardEvent) return
+
+    state.pressedKeyCombination.keyUp(key)
+  }
+
+  const restoreRemovedShortcuts = () => {
+    if (
+      confirm(
+        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？'
+      )
+    ) {
+      LocalStorage.remove(REMOVED_IDS_KEY)
+      state.removedIdSet = new Set<string>()
+      resetTypingState()
+      state.shortcut = state.shortcuts[0]
+    }
+  }
+
+  const selectToolAndCategories = (tool: string, categories: string[]) => {
+    state.tool = tool
+    LocalStorage.set(SELECTED_TOOL_KEY, tool)
+
+    state.categories = new Set(categories)
+    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
+
+    state.shortcuts = shortcutCatalog.where({
+      tool,
+      categories,
+    })
+
+    state.shortcut =
+      state.shortcuts.find((shortcut) => !state.removedIdSet.has(shortcut.id)) ??
+      state.shortcuts[0]
+
+    exitSelectionOfToolAndCategories()
+  }
+
+  const exitSelectionOfToolAndCategories = () => {
+    resetTypingState()
+    state.isListeningKeyboardEvent = true
+  }
+
+  const masteredRateOfEachTool = () =>
+    shortcutCatalog.tools().map((tool) => {
+      const shortcuts = shortcutCatalog.where({ tool })
+      const countOfShortcut = shortcuts.filter(
+        (shortcut) => !state.removedIdSet.has(shortcut.id)
+      ).length
+      const masteredIds = [...state.answeredHistoryMap]
+        .map(([id, results]): [string, number] => [id, weight(results)])
+        .filter(([, currentWeight]) => currentWeight <= 0.6)
+        .map(([id]) => id)
+      const countOfMastered = shortcuts.filter(
+        (shortcut) =>
+          masteredIds.includes(shortcut.id) &&
+          !state.removedIdSet.has(shortcut.id)
+      ).length
+
+      return {
+        name: tool,
+        masteredRate: Math.floor((countOfMastered / countOfShortcut) * 100),
+      }
+    })
+
+  const categoriesWithMasteredRate = (tool: string) => {
+    const shortcutsOfTool = shortcutCatalog.where({ tool })
+    const masteredIds = [...state.answeredHistoryMap]
+      .map(([id, results]): [string, number] => [id, weight(results)])
+      .filter(([, currentWeight]) => currentWeight <= 0.6)
+      .map(([id]) => id)
+
+    return shortcutCatalog.categoriesOf(tool).map((categoryName) => {
+      const shortcutsOfCategory = shortcutsOfTool.filter(
+        (shortcut) =>
+          shortcut.category === categoryName &&
+          !state.removedIdSet.has(shortcut.id)
+      )
+      const masteredShortcutsOfCategory = shortcutsOfCategory.filter((shortcut) =>
+        masteredIds.includes(shortcut.id)
+      )
+
+      return {
+        name: categoryName,
+        masteredRate: Math.floor(
+          (masteredShortcutsOfCategory.length / shortcutsOfCategory.length) * 100
+        ),
+      }
+    })
+  }
+
+  const onFullscreenchange = () => {
+    state.isFullscreenMode = !!document.fullscreenElement
+    state.pressedKeyCombination.reset()
+  }
+
+  return {
+    correctKeyCombinations,
+    availableIds,
+    answeredIds,
+    noAnsweredAvailableIds,
+    idToWeightMap,
+    availableIdToWeightMap,
+    countsOfEachStatus,
+    wordsOfDescriptionFilledByCorrectKeys,
+    wordsOfDescriptionFilledByPressedKeys,
+    needsFullscreenMode,
+    removedShortcutExists,
+    isRemovedAll,
+    keyDown,
+    keyUp,
+    judge,
+    restoreRemovedShortcuts,
+    selectToolAndCategories,
+    masteredRateOfEachTool,
+    exitSelectionOfToolAndCategories,
+    onFullscreenchange,
+    categoriesWithMasteredRate,
+  }
+}
+
+export default createShortcutTrainingSession

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -15,6 +15,19 @@ import sample from '@/utils/sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
 import { weightedSampleKey } from '@/utils/weighted-sample'
 
+const createEmptyShortcut = (): Shortcut => ({
+  id: '',
+  app: '',
+  os: '',
+  category: '',
+  action: '',
+  keysDescription: '',
+  keyCombinations: [],
+  isAvailable: false,
+  unavailableReason: null,
+  needsFillInBlankMode: false,
+})
+
 export type ShortcutTrainingState = {
   tool: string
   categories: Set<string>
@@ -187,12 +200,19 @@ export const createShortcutTrainingSession = (
     if (unansweredAvailableIdList.length === 0) {
       const nextId = deps.weightedSampleKey(availableIdToWeightMap())
 
-      return (shortcutByIdMap.get(nextId) ?? state.shortcuts[0]) as Shortcut
+      return (
+        shortcutByIdMap.get(nextId) ??
+        state.shortcuts[0] ??
+        createEmptyShortcut()
+      )
     }
 
     if (unansweredAvailableIdList.length === 1) {
-      return (shortcutByIdMap.get(unansweredAvailableIdList[0]) ??
-        state.shortcuts[0]) as Shortcut
+      return (
+        shortcutByIdMap.get(unansweredAvailableIdList[0]) ??
+        state.shortcuts[0] ??
+        createEmptyShortcut()
+      )
     }
 
     const unansweredAvailableShortcuts = state.shortcuts
@@ -222,16 +242,21 @@ export const createShortcutTrainingSession = (
 
   const judge = () => {
     if (!state.pressedKeyCombination.hasPressedSomeKey()) return
+    const currentCorrectKeyCombinations = correctKeyCombinations()
+    const isFullscreenOnlyShortcut =
+      currentCorrectKeyCombinations.hasOnlyAvailableInFullscreen() &&
+      !state.isFullscreenMode
+
     if (
       state.pressedKeyCombination.isModifierKey() &&
-      !correctKeyCombinations().hasOnlyModifierKeys()
+      !currentCorrectKeyCombinations.hasOnlyModifierKeys()
     ) {
       return
     }
 
     if (
       state.pressedKeyCombination.isOnlyEnterKey() &&
-      !correctKeyCombinations().hasOnlyEnterKey()
+      !currentCorrectKeyCombinations.hasOnlyEnterKey()
     ) {
       state.shortcut = nextShortcut()
       resetTypingState()
@@ -253,8 +278,8 @@ export const createShortcutTrainingSession = (
       return
     }
 
-    if (state.shortcut.isAvailable && !needsFullscreenMode()) {
-      if (correctKeyCombinations().has(state.pressedKeyCombination)) {
+    if (state.shortcut.isAvailable && !isFullscreenOnlyShortcut) {
+      if (currentCorrectKeyCombinations.has(state.pressedKeyCombination)) {
         effects.respondToCorrectKey()
       } else if (
         !state.isWrongKeyPressed &&
@@ -310,7 +335,7 @@ export const createShortcutTrainingSession = (
     state.shortcut =
       state.shortcuts.find(
         (shortcut) => !state.removedIdSet.has(shortcut.id),
-      ) ?? state.shortcuts[0]
+      ) ?? state.shortcuts[0] ?? createEmptyShortcut()
 
     exitSelectionOfToolAndCategories()
   }

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -114,14 +114,14 @@ export const createShortcutTrainingSession = (
       ),
     )
 
-  const shortcutsIds = () => state.shortcuts.map((shortcut) => shortcut.id)
+  const shortcutIds = () => state.shortcuts.map((shortcut) => shortcut.id)
 
   const availableIds = () =>
-    shortcutsIds().filter((id) => !state.removedIdSet.has(id))
+    shortcutIds().filter((id) => !state.removedIdSet.has(id))
 
   const answeredIdSet = () => new Set(state.answeredHistoryMap.keys())
 
-  const noAnsweredAvailableIds = () =>
+  const unansweredAvailableIds = () =>
     availableIds().filter((id) => !answeredIdSet().has(id))
 
   const availableIdToWeightMap = () => {
@@ -178,28 +178,28 @@ export const createShortcutTrainingSession = (
     state.shortcuts.every((shortcut) => state.removedIdSet.has(shortcut.id))
 
   const nextShortcut = () => {
-    const noAnsweredAvailableIdList = noAnsweredAvailableIds()
-    const noAnsweredAvailableIdSet = new Set(noAnsweredAvailableIdList)
+    const unansweredAvailableIdList = unansweredAvailableIds()
+    const unansweredAvailableIdSet = new Set(unansweredAvailableIdList)
     const shortcutByIdMap = new Map(
       state.shortcuts.map((shortcut) => [shortcut.id, shortcut] as const),
     )
 
-    if (noAnsweredAvailableIdList.length === 0) {
+    if (unansweredAvailableIdList.length === 0) {
       const nextId = deps.weightedSampleKey(availableIdToWeightMap())
 
       return (shortcutByIdMap.get(nextId) ?? state.shortcuts[0]) as Shortcut
     }
 
-    if (noAnsweredAvailableIdList.length === 1) {
-      return (shortcutByIdMap.get(noAnsweredAvailableIdList[0]) ??
+    if (unansweredAvailableIdList.length === 1) {
+      return (shortcutByIdMap.get(unansweredAvailableIdList[0]) ??
         state.shortcuts[0]) as Shortcut
     }
 
-    const noAnsweredAvailableShortcuts = state.shortcuts
-      .filter((shortcut) => noAnsweredAvailableIdSet.has(shortcut.id))
+    const unansweredAvailableShortcuts = state.shortcuts
+      .filter((shortcut) => unansweredAvailableIdSet.has(shortcut.id))
       .filter((shortcut) => shortcut.id !== state.shortcut.id)
 
-    return deps.sample(noAnsweredAvailableShortcuts)
+    return deps.sample(unansweredAvailableShortcuts)
   }
 
   const resetTypingState = () => {
@@ -332,7 +332,7 @@ export const createShortcutTrainingSession = (
   return {
     correctKeyCombinations,
     availableIds,
-    noAnsweredAvailableIds,
+    unansweredAvailableIds,
     availableIdToWeightMap,
     countsOfEachStatus,
     masteredRateOfEachTool,

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -335,7 +335,9 @@ export const createShortcutTrainingSession = (
     state.shortcut =
       state.shortcuts.find(
         (shortcut) => !state.removedIdSet.has(shortcut.id),
-      ) ?? state.shortcuts[0] ?? createEmptyShortcut()
+      ) ??
+      state.shortcuts[0] ??
+      createEmptyShortcut()
 
     exitSelectionOfToolAndCategories()
   }

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -42,8 +42,8 @@ export type ShortcutTrainingSessionDeps = {
   weightedSampleKey: typeof weightedSampleKey
   scheduleRestartTyping: (callback: () => void) => void
   toggleFullscreen: () => void
-  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => void
-  persistRemovedIds: (removedIds: string[]) => void
+  persistAnsweredHistory: (answeredHistory: Map<string, boolean[]>) => void
+  persistRemovedIds: (removedIds: Set<string>) => void
   persistSelectedTool: (tool: string) => void
   persistSelectedCategories: (categories: string[]) => void
 }
@@ -61,8 +61,8 @@ export const createShortcutTrainingState = ({
   categories: string[]
   shortcuts: Shortcut[]
   shortcut: Shortcut
-  removedIds: string[]
-  answeredHistory: Record<string, boolean[]>
+  removedIds: Set<string>
+  answeredHistory: Map<string, boolean[]>
   isFullscreenMode: boolean
 }): ShortcutTrainingState => ({
   tool,
@@ -83,9 +83,7 @@ export const createShortcutTrainingState = ({
 
   pressedKeyCombination: new KeyCombination(),
   removedIdSet: new Set<string>(removedIds),
-  answeredHistoryMap: new Map<string, boolean[]>(
-    Object.entries(answeredHistory),
-  ),
+  answeredHistoryMap: new Map<string, boolean[]>(answeredHistory),
 })
 
 const defaultSessionDeps: ShortcutTrainingSessionDeps = {
@@ -105,8 +103,8 @@ const defaultSessionDeps: ShortcutTrainingSessionDeps = {
 
 export const createShortcutTrainingSession = (
   state: ShortcutTrainingState,
-  deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
   catalogSummary: ShortcutCatalogSummary,
+  deps: ShortcutTrainingSessionDeps = defaultSessionDeps,
 ) => {
   const correctKeyCombinations = () =>
     new KeyCombinations(
@@ -218,7 +216,7 @@ export const createShortcutTrainingSession = (
       state.answeredHistoryMap.set(id, [result])
     }
 
-    deps.persistAnsweredHistory(Object.fromEntries(state.answeredHistoryMap))
+    deps.persistAnsweredHistory(state.answeredHistoryMap)
   }
 
   const respondToSelectToolsKey = () => {
@@ -236,7 +234,7 @@ export const createShortcutTrainingSession = (
     state.isListeningKeyboardEvent = false
     state.isRemoveKeyPressed = true
     state.removedIdSet.add(state.shortcut.id)
-    deps.persistRemovedIds([...state.removedIdSet])
+    deps.persistRemovedIds(state.removedIdSet)
 
     deps.scheduleRestartTyping(() => {
       state.shortcut = nextShortcut()
@@ -376,7 +374,7 @@ export const createShortcutTrainingSession = (
         'すべてのショートカットキーが出題されるようになります。\nよろしいですか？',
       )
     ) {
-      deps.persistRemovedIds([])
+      deps.persistRemovedIds(new Set())
       state.removedIdSet = new Set<string>()
       resetTypingState()
       state.shortcut = state.shortcuts[0]

--- a/src/models/shortcut-training-session.ts
+++ b/src/models/shortcut-training-session.ts
@@ -1,11 +1,16 @@
-import { Shortcut, KeyCombinable } from '@/types/interfaces'
 import KeyCombination from '@/models/key-combination'
 import KeyCombinations from '@/models/key-combinations'
+import shortcutCatalog from '@/models/shortcut-catalog'
+import {
+  getAvailableIdToWeightMap,
+  getCountsOfEachStatus,
+} from '@/models/shortcut-training-session-status'
+import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
+import type { KeyCombinable, Shortcut } from '@/types/interfaces'
 import Keyboard from '@/utils/keyboard'
 import sample from '@/utils/sample'
-import shortcutCatalog from '@/models/shortcut-catalog'
-import { weight, weightedSampleKey } from '@/utils/weighted-sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
+import { weightedSampleKey } from '@/utils/weighted-sample'
 
 export type ShortcutTrainingState = {
   tool: string
@@ -117,66 +122,28 @@ export const createShortcutTrainingSession = (
   const noAnsweredAvailableIds = () =>
     availableIds().filter((id) => !answeredIds().includes(id))
 
-  const idToWeightMap = () => {
-    const idToWeightMap = new Map<string, number>()
-
-    for (const [id, results] of state.answeredHistoryMap.entries()) {
-      if (shortcutsIds().includes(id)) {
-        idToWeightMap.set(id, weight(results))
-      }
-    }
-
-    return idToWeightMap
-  }
-
   const availableIdToWeightMap = () => {
-    const availableIdToWeightMap = new Map<string, number>()
-
-    for (const [id, currentWeight] of idToWeightMap().entries()) {
-      if (availableIds().includes(id)) {
-        availableIdToWeightMap.set(id, currentWeight)
-      }
-    }
-
-    return availableIdToWeightMap
+    return getAvailableIdToWeightMap({
+      shortcuts: state.shortcuts,
+      removedIds: state.removedIdSet,
+      answeredHistory: state.answeredHistoryMap,
+    })
   }
 
   const countsOfEachStatus = () => {
-    const [masteredIds, unmasteredIds] = Array.from(idToWeightMap()).reduce<
-      [string[], string[]]
-    >(
-      ([masteredIds, unmasteredIds], [id, currentWeight]) =>
-        currentWeight <= 0.6
-          ? [[...masteredIds, id], unmasteredIds]
-          : [masteredIds, [...unmasteredIds, id]],
-      [[], []],
-    )
-
-    const noAnsweredIds = shortcutsIds().filter(
-      (id) => !answeredIds().includes(id),
-    )
-
-    return {
-      mastered: {
-        included: masteredIds.filter((id) => availableIds().includes(id))
-          .length,
-        removed: masteredIds.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-      unmastered: {
-        included: unmasteredIds.filter((id) => availableIds().includes(id))
-          .length,
-        removed: unmasteredIds.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-      noAnswered: {
-        included: noAnsweredIds.filter((id) => availableIds().includes(id))
-          .length,
-        removed: noAnsweredIds.filter((id) => !availableIds().includes(id))
-          .length,
-      },
-    }
+    return getCountsOfEachStatus({
+      shortcuts: state.shortcuts,
+      removedIds: state.removedIdSet,
+      answeredHistory: state.answeredHistoryMap,
+    })
   }
+
+  const createSummary = () =>
+    createShortcutTrainingSessionSummary({
+      shortcuts: state.shortcuts,
+      removedIds: new Set(state.removedIdSet),
+      answeredHistory: new Map(state.answeredHistoryMap),
+    })
 
   const wordsOfDescriptionFilledByCorrectKeys = () =>
     Keyboard.splitByKeyDescription(state.shortcut.keysDescription).map(
@@ -440,14 +407,19 @@ export const createShortcutTrainingSession = (
     state.pressedKeyCombination.reset()
   }
 
+  const masteredRateOfEachTool = () => createSummary().masteredRateOfEachTool()
+  const categoriesWithMasteredRate = (tool: string) =>
+    createSummary().categoriesWithMasteredRate(tool)
+
   return {
     correctKeyCombinations,
     availableIds,
     answeredIds,
     noAnsweredAvailableIds,
-    idToWeightMap,
     availableIdToWeightMap,
     countsOfEachStatus,
+    masteredRateOfEachTool,
+    categoriesWithMasteredRate,
     wordsOfDescriptionFilledByCorrectKeys,
     wordsOfDescriptionFilledByPressedKeys,
     needsFullscreenMode,

--- a/src/stores/game-key.ts
+++ b/src/stores/game-key.ts
@@ -2,5 +2,5 @@ import type { InjectionKey } from 'vue'
 
 import type { GameStore } from '@/stores/game'
 
-const GameKey: InjectionKey<GameStore> = Symbol('gameStore')
+const GameKey: InjectionKey<GameStore> = Symbol('shortcutTrainingSessionStore')
 export default GameKey

--- a/src/stores/game-session-storage.ts
+++ b/src/stores/game-session-storage.ts
@@ -14,10 +14,13 @@ export type GameSessionStorageSnapshot = {
 }
 
 export const loadGameSessionStorage = (): GameSessionStorageSnapshot => ({
-  selectedTool: LocalStorage.get(SELECTED_TOOL_KEY),
-  selectedCategories: LocalStorage.get(SELECTED_CATEGORIES_KEY),
-  removedIds: [...LocalStorage.get(REMOVED_IDS_KEY)],
-  answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+  selectedTool: LocalStorage.get(SELECTED_TOOL_KEY) as string,
+  selectedCategories: LocalStorage.get(SELECTED_CATEGORIES_KEY) as string[],
+  removedIds: [...(LocalStorage.get(REMOVED_IDS_KEY) as string[])],
+  answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY) as Record<
+    string,
+    boolean[]
+  >,
 })
 
 export const createGameSessionStoragePersistence = () => ({

--- a/src/stores/game-session-storage.ts
+++ b/src/stores/game-session-storage.ts
@@ -1,0 +1,36 @@
+import {
+  ANSWERED_HISTORY_KEY,
+  REMOVED_IDS_KEY,
+  SELECTED_CATEGORIES_KEY,
+  SELECTED_TOOL_KEY,
+} from '@/constants/local-storage-keys'
+import LocalStorage from '@/utils/local-storage'
+
+export type GameSessionStorageSnapshot = {
+  selectedTool: string
+  selectedCategories: string[]
+  removedIds: string[]
+  answeredHistory: Record<string, boolean[]>
+}
+
+export const loadGameSessionStorage = (): GameSessionStorageSnapshot => ({
+  selectedTool: LocalStorage.get(SELECTED_TOOL_KEY),
+  selectedCategories: LocalStorage.get(SELECTED_CATEGORIES_KEY),
+  removedIds: [...LocalStorage.get(REMOVED_IDS_KEY)],
+  answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+})
+
+export const createGameSessionStoragePersistence = () => ({
+  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => {
+    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
+  },
+  persistRemovedIds: (removedIds: string[]) => {
+    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
+  },
+  persistSelectedTool: (tool: string) => {
+    LocalStorage.set(SELECTED_TOOL_KEY, tool)
+  },
+  persistSelectedCategories: (categories: string[]) => {
+    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
+  },
+})

--- a/src/stores/game-session-storage.ts
+++ b/src/stores/game-session-storage.ts
@@ -9,26 +9,27 @@ import LocalStorage from '@/utils/local-storage'
 export type GameSessionStorageSnapshot = {
   selectedTool: string
   selectedCategories: string[]
-  removedIds: string[]
-  answeredHistory: Record<string, boolean[]>
+  removedIds: Set<string>
+  answeredHistory: Map<string, boolean[]>
 }
 
 export const loadGameSessionStorage = (): GameSessionStorageSnapshot => ({
   selectedTool: LocalStorage.get(SELECTED_TOOL_KEY) as string,
   selectedCategories: LocalStorage.get(SELECTED_CATEGORIES_KEY) as string[],
-  removedIds: [...(LocalStorage.get(REMOVED_IDS_KEY) as string[])],
-  answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY) as Record<
-    string,
-    boolean[]
-  >,
+  removedIds: new Set(LocalStorage.get(REMOVED_IDS_KEY) as string[]),
+  answeredHistory: new Map(
+    Object.entries(
+      LocalStorage.get(ANSWERED_HISTORY_KEY) as Record<string, boolean[]>,
+    ),
+  ),
 })
 
 export const createGameSessionStoragePersistence = () => ({
-  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => {
-    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
+  persistAnsweredHistory: (answeredHistory: Map<string, boolean[]>) => {
+    LocalStorage.set(ANSWERED_HISTORY_KEY, Object.fromEntries(answeredHistory))
   },
-  persistRemovedIds: (removedIds: string[]) => {
-    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
+  persistRemovedIds: (removedIds: Set<string>) => {
+    LocalStorage.set(REMOVED_IDS_KEY, [...removedIds])
   },
   persistSelectedTool: (tool: string) => {
     LocalStorage.set(SELECTED_TOOL_KEY, tool)

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -33,11 +33,11 @@ export const createGameSessionBootstrap = ({
   isFullscreenMode,
   shortcuts,
 }: GameSessionBootstrapInput): GameSessionBootstrap => {
-  const selectedAvailableShortcuts = selectedShortcuts.filter(
+  const availableSelectedShortcuts = selectedShortcuts.filter(
     (shortcut) => !removedIds.has(shortcut.id),
   )
-  const availableShortcuts = shortcuts ?? selectedAvailableShortcuts
-  const shortcut =
+  const availableShortcuts = shortcuts ?? availableSelectedShortcuts
+  const initialShortcut =
     import.meta.env.MODE === 'test'
       ? availableShortcuts[0]
       : sample(availableShortcuts)
@@ -46,7 +46,7 @@ export const createGameSessionBootstrap = ({
     tool,
     categories,
     shortcuts: shortcuts ?? selectedShortcuts,
-    shortcut,
+    shortcut: initialShortcut,
     removedIds,
     answeredHistory,
     isFullscreenMode,

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -1,15 +1,12 @@
-import {
-  ANSWERED_HISTORY_KEY,
-  REMOVED_IDS_KEY,
-  SELECTED_CATEGORIES_KEY,
-  SELECTED_TOOL_KEY,
-} from '@/constants/local-storage-keys'
 import shortcutCatalog from '@/models/shortcut-catalog'
 import type { Shortcut } from '@/types/interfaces'
-import LocalStorage from '@/utils/local-storage'
 import sample from '@/utils/sample'
 import { weightedSampleKey } from '@/utils/weighted-sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
+import {
+  createGameSessionStoragePersistence,
+  loadGameSessionStorage,
+} from '@/stores/game-session-storage'
 
 export type GameSessionBootstrap = {
   tool: string
@@ -24,13 +21,16 @@ export type GameSessionBootstrap = {
 export const createGameSessionBootstrap = (
   shortcuts?: Shortcut[],
 ): GameSessionBootstrap => {
-  const selectedTool = LocalStorage.get(SELECTED_TOOL_KEY)
-  const selectedCategories = LocalStorage.get(SELECTED_CATEGORIES_KEY)
+  const {
+    selectedTool,
+    selectedCategories,
+    removedIds,
+    answeredHistory,
+  } = loadGameSessionStorage()
   const selectedShortcuts = shortcutCatalog.where({
     tool: selectedTool,
     categories: selectedCategories,
   })
-  const removedIds = [...LocalStorage.get(REMOVED_IDS_KEY)]
   const selectedAvailableShortcuts = selectedShortcuts.filter(
     (shortcut) => !removedIds.includes(shortcut.id),
   )
@@ -46,7 +46,7 @@ export const createGameSessionBootstrap = (
     shortcuts: shortcuts ?? selectedShortcuts,
     shortcut,
     removedIds,
-    answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+    answeredHistory,
     isFullscreenMode: !!document.fullscreenElement,
   }
 }
@@ -59,16 +59,5 @@ export const createGameSessionDeps = () => ({
     setTimeout(callback, import.meta.env.MODE === 'test' ? 0 : 1000)
   },
   toggleFullscreen,
-  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => {
-    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
-  },
-  persistRemovedIds: (removedIds: string[]) => {
-    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
-  },
-  persistSelectedTool: (tool: string) => {
-    LocalStorage.set(SELECTED_TOOL_KEY, tool)
-  },
-  persistSelectedCategories: (categories: string[]) => {
-    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
-  },
+  ...createGameSessionStoragePersistence(),
 })

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -4,6 +4,19 @@ import sample from '@/utils/sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
 import { weightedSampleKey } from '@/utils/weighted-sample'
 
+const createEmptyShortcut = (): Shortcut => ({
+  id: '',
+  app: '',
+  os: '',
+  category: '',
+  action: '',
+  keysDescription: '',
+  keyCombinations: [],
+  isAvailable: false,
+  unavailableReason: null,
+  needsFillInBlankMode: false,
+})
+
 export type GameSessionBootstrap = {
   tool: string
   categories: string[]
@@ -46,7 +59,7 @@ export const createGameSessionBootstrap = ({
     tool,
     categories,
     shortcuts: shortcuts ?? selectedShortcuts,
-    shortcut: initialShortcut,
+    shortcut: initialShortcut ?? createEmptyShortcut(),
     removedIds,
     answeredHistory,
     isFullscreenMode,

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -1,12 +1,12 @@
 import shortcutCatalog from '@/models/shortcut-catalog'
-import type { Shortcut } from '@/types/interfaces'
-import sample from '@/utils/sample'
-import { weightedSampleKey } from '@/utils/weighted-sample'
-import toggleFullscreen from '@/utils/toggle-fullscreen'
 import {
   createGameSessionStoragePersistence,
   loadGameSessionStorage,
 } from '@/stores/game-session-storage'
+import type { Shortcut } from '@/types/interfaces'
+import sample from '@/utils/sample'
+import toggleFullscreen from '@/utils/toggle-fullscreen'
+import { weightedSampleKey } from '@/utils/weighted-sample'
 
 export type GameSessionBootstrap = {
   tool: string
@@ -21,12 +21,8 @@ export type GameSessionBootstrap = {
 export const createGameSessionBootstrap = (
   shortcuts?: Shortcut[],
 ): GameSessionBootstrap => {
-  const {
-    selectedTool,
-    selectedCategories,
-    removedIds,
-    answeredHistory,
-  } = loadGameSessionStorage()
+  const { selectedTool, selectedCategories, removedIds, answeredHistory } =
+    loadGameSessionStorage()
   const selectedShortcuts = shortcutCatalog.where({
     tool: selectedTool,
     categories: selectedCategories,

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -1,0 +1,74 @@
+import {
+  ANSWERED_HISTORY_KEY,
+  REMOVED_IDS_KEY,
+  SELECTED_CATEGORIES_KEY,
+  SELECTED_TOOL_KEY,
+} from '@/constants/local-storage-keys'
+import shortcutCatalog from '@/models/shortcut-catalog'
+import type { Shortcut } from '@/types/interfaces'
+import LocalStorage from '@/utils/local-storage'
+import sample from '@/utils/sample'
+import { weightedSampleKey } from '@/utils/weighted-sample'
+import toggleFullscreen from '@/utils/toggle-fullscreen'
+
+export type GameSessionBootstrap = {
+  tool: string
+  categories: string[]
+  shortcuts: Shortcut[]
+  shortcut: Shortcut
+  removedIds: string[]
+  answeredHistory: Record<string, boolean[]>
+  isFullscreenMode: boolean
+}
+
+export const createGameSessionBootstrap = (
+  shortcuts?: Shortcut[],
+): GameSessionBootstrap => {
+  const selectedTool = LocalStorage.get(SELECTED_TOOL_KEY)
+  const selectedCategories = LocalStorage.get(SELECTED_CATEGORIES_KEY)
+  const selectedShortcuts = shortcutCatalog.where({
+    tool: selectedTool,
+    categories: selectedCategories,
+  })
+  const removedIds = [...LocalStorage.get(REMOVED_IDS_KEY)]
+  const selectedAvailableShortcuts = selectedShortcuts.filter(
+    (shortcut) => !removedIds.includes(shortcut.id),
+  )
+  const availableShortcuts = shortcuts ?? selectedAvailableShortcuts
+  const shortcut =
+    import.meta.env.MODE === 'test'
+      ? availableShortcuts[0]
+      : sample(availableShortcuts)
+
+  return {
+    tool: selectedTool,
+    categories: selectedCategories,
+    shortcuts: shortcuts ?? selectedShortcuts,
+    shortcut,
+    removedIds,
+    answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+    isFullscreenMode: !!document.fullscreenElement,
+  }
+}
+
+export const createGameSessionDeps = () => ({
+  isFullscreenMode: () => !!document.fullscreenElement,
+  sample,
+  weightedSampleKey,
+  scheduleRestartTyping: (callback: () => void) => {
+    setTimeout(callback, import.meta.env.MODE === 'test' ? 0 : 1000)
+  },
+  toggleFullscreen,
+  persistAnsweredHistory: (answeredHistory: Record<string, boolean[]>) => {
+    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
+  },
+  persistRemovedIds: (removedIds: string[]) => {
+    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
+  },
+  persistSelectedTool: (tool: string) => {
+    LocalStorage.set(SELECTED_TOOL_KEY, tool)
+  },
+  persistSelectedCategories: (categories: string[]) => {
+    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
+  },
+})

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -1,8 +1,4 @@
-import shortcutCatalog from '@/models/shortcut-catalog'
-import {
-  createGameSessionStoragePersistence,
-  loadGameSessionStorage,
-} from '@/stores/game-session-storage'
+import { createGameSessionStoragePersistence } from '@/stores/game-session-storage'
 import type { Shortcut } from '@/types/interfaces'
 import sample from '@/utils/sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
@@ -18,15 +14,25 @@ export type GameSessionBootstrap = {
   isFullscreenMode: boolean
 }
 
-export const createGameSessionBootstrap = (
-  shortcuts?: Shortcut[],
-): GameSessionBootstrap => {
-  const { selectedTool, selectedCategories, removedIds, answeredHistory } =
-    loadGameSessionStorage()
-  const selectedShortcuts = shortcutCatalog.where({
-    tool: selectedTool,
-    categories: selectedCategories,
-  })
+export type GameSessionBootstrapInput = {
+  tool: string
+  categories: string[]
+  selectedShortcuts: Shortcut[]
+  removedIds: Set<string>
+  answeredHistory: Map<string, boolean[]>
+  isFullscreenMode: boolean
+  shortcuts?: Shortcut[]
+}
+
+export const createGameSessionBootstrap = ({
+  tool,
+  categories,
+  selectedShortcuts,
+  removedIds,
+  answeredHistory,
+  isFullscreenMode,
+  shortcuts,
+}: GameSessionBootstrapInput): GameSessionBootstrap => {
   const selectedAvailableShortcuts = selectedShortcuts.filter(
     (shortcut) => !removedIds.has(shortcut.id),
   )
@@ -37,13 +43,13 @@ export const createGameSessionBootstrap = (
       : sample(availableShortcuts)
 
   return {
-    tool: selectedTool,
-    categories: selectedCategories,
+    tool,
+    categories,
     shortcuts: shortcuts ?? selectedShortcuts,
     shortcut,
     removedIds,
     answeredHistory,
-    isFullscreenMode: !!document.fullscreenElement,
+    isFullscreenMode,
   }
 }
 

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -1,21 +1,9 @@
+import { createEmptyShortcut } from '@/models/empty-shortcut'
 import { createGameSessionStoragePersistence } from '@/stores/game-session-storage'
 import type { Shortcut } from '@/types/interfaces'
 import sample from '@/utils/sample'
 import toggleFullscreen from '@/utils/toggle-fullscreen'
 import { weightedSampleKey } from '@/utils/weighted-sample'
-
-const createEmptyShortcut = (): Shortcut => ({
-  id: '',
-  app: '',
-  os: '',
-  category: '',
-  action: '',
-  keysDescription: '',
-  keyCombinations: [],
-  isAvailable: false,
-  unavailableReason: null,
-  needsFillInBlankMode: false,
-})
 
 export type GameSessionBootstrap = {
   tool: string

--- a/src/stores/game-session.ts
+++ b/src/stores/game-session.ts
@@ -13,8 +13,8 @@ export type GameSessionBootstrap = {
   categories: string[]
   shortcuts: Shortcut[]
   shortcut: Shortcut
-  removedIds: string[]
-  answeredHistory: Record<string, boolean[]>
+  removedIds: Set<string>
+  answeredHistory: Map<string, boolean[]>
   isFullscreenMode: boolean
 }
 
@@ -28,7 +28,7 @@ export const createGameSessionBootstrap = (
     categories: selectedCategories,
   })
   const selectedAvailableShortcuts = selectedShortcuts.filter(
-    (shortcut) => !removedIds.includes(shortcut.id),
+    (shortcut) => !removedIds.has(shortcut.id),
   )
   const availableShortcuts = shortcuts ?? selectedAvailableShortcuts
   const shortcut =

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -30,10 +30,12 @@ const createGameStore = (shortcuts?: Shortcut[]) => {
     isFullscreenMode: !!document.fullscreenElement,
     shortcuts,
   })
-  const state = reactive(createShortcutTrainingState(bootstrap))
+  const state = reactive<ShortcutTrainingState>(
+    createShortcutTrainingState(bootstrap),
+  )
 
   const trainingSession = createShortcutTrainingSession(
-    state as unknown as ShortcutTrainingState,
+    state,
     createShortcutCatalogSummary(),
     createGameSessionDeps(),
   )

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -6,20 +6,19 @@ import {
   SELECTED_CATEGORIES_KEY,
   SELECTED_TOOL_KEY,
 } from '@/constants/local-storage-keys'
-import TOOL_TO_SHORTCUTS_MAP from '@/constants/tool-to-shortcuts-map'
-import KeyCombination from '@/models/key-combination'
-import KeyCombinations from '@/models/key-combinations'
-import type { KeyCombinable, Shortcut } from '@/types/interfaces'
-import Keyboard from '@/utils/keyboard'
+import shortcutCatalog from '@/models/shortcut-catalog'
+import {
+  createShortcutTrainingSession,
+  createShortcutTrainingState,
+  type ShortcutTrainingState,
+} from '@/models/shortcut-training-session'
+import type { Shortcut } from '@/types/interfaces'
 import LocalStorage from '@/utils/local-storage'
 import sample from '@/utils/sample'
-import shortcutStorage from '@/utils/shortcut-storage'
-import toggleFullscreen from '@/utils/toggle-fullscreen'
-import { weight, weightedSampleKey } from '@/utils/weighted-sample'
 
 const selectedTool = LocalStorage.get(SELECTED_TOOL_KEY)
 const selectedCategories = LocalStorage.get(SELECTED_CATEGORIES_KEY)
-const selectedShortcuts = shortcutStorage.where({
+const selectedShortcuts = shortcutCatalog.where({
   tool: selectedTool,
   categories: selectedCategories,
 })
@@ -30,452 +29,43 @@ const selectedAvailableShortcuts = selectedShortcuts.filter(
   (shortcut) => !removedIds.includes(shortcut.id),
 )
 
-const TimeIntervalToRestartTyping = import.meta.env.MODE === 'test' ? 0 : 1000
+const createInitialShortcut = (
+  shortcuts: Shortcut[] | undefined,
+  selectedShortcuts: Shortcut[],
+) => {
+  const availableShortcuts = shortcuts ?? selectedShortcuts
+
+  if (import.meta.env.MODE === 'test') {
+    return availableShortcuts[0]
+  }
+
+  return sample(availableShortcuts)
+}
 
 const gameStore = (shortcuts?: Shortcut[]) => {
-  const state = reactive({
-    tool: selectedTool,
-    categories: new Set(selectedCategories) as Set<string>,
-    shortcuts: shortcuts ?? selectedShortcuts,
-    shortcut:
-      import.meta.env.MODE === 'test'
-        ? (shortcuts ?? selectedAvailableShortcuts)[0] // 出題順に依存しているテストがあるため
-        : sample(shortcuts ?? selectedAvailableShortcuts),
+  const state = reactive(
+    createShortcutTrainingState({
+      tool: selectedTool,
+      categories: selectedCategories,
+      shortcuts: shortcuts ?? selectedShortcuts,
+      shortcut: createInitialShortcut(shortcuts, selectedAvailableShortcuts),
+      removedIds,
+      answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+    }),
+  ) as unknown as ShortcutTrainingState
 
-    isListeningKeyboardEvent: true,
-    isCorrectKeyPressed: false,
-    isWrongKeyPressed: false,
-    isRemoveKeyPressed: false,
-    isSelectToolsKeyPressed: false,
-    isShowCorrectKeyPressed: false,
-    isMarkedSelfAsCorrect: false,
-    isMarkedSelfAsWrong: false,
-    isShakingKeyCombinationView: false,
-    isFullscreenMode:
-      !!document.fullscreenElement && document.fullscreenElement !== null,
+  const session = createShortcutTrainingSession(state)
 
-    pressedKeyCombination: new KeyCombination(),
-    removedIdSet: new Set<string>(removedIds),
-    answeredHistoryMap: new Map<string, boolean[]>(
-      Object.entries(LocalStorage.get(ANSWERED_HISTORY_KEY)),
-    ),
-  })
-
-  const correctKeyCombinations = computed(
-    () =>
-      new KeyCombinations(
-        state.shortcut.keyCombinations.map(
-          (keyCombination) => new KeyCombination(keyCombination),
-        ),
-      ),
-  )
-
-  const shortcutsIds = computed(() =>
-    state.shortcuts.map((shortcut) => shortcut.id),
-  )
-
-  const availableIds = computed(() =>
-    shortcutsIds.value.filter((id) => !state.removedIdSet.has(id)),
-  )
-
-  const answeredIds = computed(() => {
-    return Array.from(state.answeredHistoryMap.keys())
-  })
-
-  const noAnsweredAvailableIds = computed(() => {
-    return availableIds.value.filter((id) => !answeredIds.value.includes(id))
-  })
-
-  const idToWeightMap = computed(() => {
-    const idToWeightMap = new Map()
-
-    for (const [id, results] of state.answeredHistoryMap.entries()) {
-      if (shortcutsIds.value.includes(id)) {
-        idToWeightMap.set(id, weight(results))
-      }
-    }
-
-    return idToWeightMap
-  })
-
-  const availableIdToWeightMap = computed(() => {
-    const availableIdToWeightMap = new Map()
-
-    for (const [id, weight] of idToWeightMap.value.entries()) {
-      if (availableIds.value.includes(id)) {
-        availableIdToWeightMap.set(id, weight)
-      }
-    }
-
-    return availableIdToWeightMap
-  })
-
-  const countsOfEachStatus = computed(() => {
-    const [masteredIds, unmasteredIds]: [string[], string[]] = [
-      ...idToWeightMap.value,
-    ].reduce(
-      ([masteredIds, unmasteredIds], [id, weight]) =>
-        weight <= 0.6
-          ? [[...masteredIds, id], unmasteredIds]
-          : [masteredIds, [...unmasteredIds, id]],
-      [[], []],
-    )
-
-    const noAnsweredIds = shortcutsIds.value.filter(
-      (id) => !answeredIds.value.includes(id),
-    )
-
-    return {
-      mastered: {
-        included: masteredIds.filter((id) => availableIds.value.includes(id))
-          .length,
-        removed: masteredIds.filter((id) => !availableIds.value.includes(id))
-          .length,
-      },
-      unmastered: {
-        included: unmasteredIds.filter((id) => availableIds.value.includes(id))
-          .length,
-        removed: unmasteredIds.filter((id) => !availableIds.value.includes(id))
-          .length,
-      },
-      noAnswered: {
-        included: noAnsweredIds.filter((id) => availableIds.value.includes(id))
-          .length,
-        removed: noAnsweredIds.filter((id) => !availableIds.value.includes(id))
-          .length,
-      },
-    }
-  })
-
+  const removedShortcutExists = computed(() => session.removedShortcutExists())
+  const isRemovedAll = computed(() => session.isRemovedAll())
   const wordsOfDescriptionFilledByCorrectKeys = computed(() =>
-    Keyboard.splitByKeyDescription(state.shortcut.keysDescription).map(
-      (word) => Keyboard.keyOfKeyDescription(word) ?? word,
-    ),
+    session.wordsOfDescriptionFilledByCorrectKeys(),
   )
-
-  const wordsOfDescriptionFilledByPressedKeys = computed(() => {
-    const pressedKeys = state.pressedKeyCombination.keys()
-
-    return Keyboard.splitByKeyDescription(state.shortcut.keysDescription)
-      .map((word) => Keyboard.keyOfKeyDescription(word) ?? word)
-      .map((word) => {
-        if (Keyboard.isKey(word) && !Keyboard.isUndetectableKey(word)) {
-          return pressedKeys.shift() ?? ''
-        } else {
-          return word
-        }
-      })
-  })
-
-  const needsFullscreenMode = computed(() => {
-    return (
-      correctKeyCombinations.value.hasOnlyAvailableInFullscreen() &&
-      !state.isFullscreenMode
-    )
-  })
-
-  const removedShortcutExists = computed(() => state.removedIdSet.size > 0)
-  const isRemovedAll = computed(() =>
-    state.shortcuts.every((shortcut) => state.removedIdSet.has(shortcut.id)),
+  const wordsOfDescriptionFilledByPressedKeys = computed(() =>
+    session.wordsOfDescriptionFilledByPressedKeys(),
   )
-
-  const keyDown = (keyCombinable: KeyCombinable) => {
-    if (isRemovedAll.value || !state.isListeningKeyboardEvent) return
-
-    state.pressedKeyCombination.keyDown(keyCombinable)
-    judge()
-  }
-
-  const keyUp = (key: string) => {
-    if (isRemovedAll.value || !state.isListeningKeyboardEvent) return
-
-    state.pressedKeyCombination.keyUp(key)
-  }
-
-  const judge = () => {
-    if (!state.pressedKeyCombination.hasPressedSomeKey()) return
-    if (
-      state.pressedKeyCombination.isModifierKey() &&
-      !correctKeyCombinations.value.hasOnlyModifierKeys()
-    )
-      return
-
-    if (
-      state.pressedKeyCombination.isOnlyEnterKey() &&
-      !correctKeyCombinations.value.hasOnlyEnterKey()
-    ) {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      return
-    } else if (state.pressedKeyCombination.isRemoveKey()) {
-      respondToRemoveKey()
-      return
-    } else if (state.pressedKeyCombination.isSelectToolsKey()) {
-      respondToSelectToolsKey()
-      return
-    } else if (state.pressedKeyCombination.isToggleFullscreenKey()) {
-      toggleFullscreen()
-      return
-    }
-
-    if (state.shortcut.isAvailable && !needsFullscreenMode.value) {
-      if (
-        correctKeyCombinations.value.has(
-          state.pressedKeyCombination as KeyCombination,
-        )
-      ) {
-        respondToCorrectKey()
-      } else if (
-        !state.isWrongKeyPressed &&
-        !state.pressedKeyCombination.isModifierKey()
-      ) {
-        respondToWrongKey()
-      }
-    } else {
-      if (
-        !state.isShowCorrectKeyPressed &&
-        state.pressedKeyCombination.isShowCorrectKey()
-      ) {
-        respondToShowCorrectKey()
-      } else if (
-        state.isShowCorrectKeyPressed &&
-        state.pressedKeyCombination.isMarkedSelfAsCorrectKey()
-      ) {
-        respondToMarkSelfAsCorrectKey()
-      } else if (
-        state.isShowCorrectKeyPressed &&
-        state.pressedKeyCombination.isMarkedSelfAsWrongKey()
-      ) {
-        respondToMarkSelfAsWrongKey()
-      }
-    }
-  }
-
-  const nextShortcut = () => {
-    if (noAnsweredAvailableIds.value.length === 0) {
-      const nextId = weightedSampleKey(availableIdToWeightMap.value)
-
-      return state.shortcuts.find(
-        (shortcut) => shortcut.id === nextId,
-      ) as Shortcut
-    } else if (noAnsweredAvailableIds.value.length === 1) {
-      return state.shortcuts.find(
-        (shortcut) => shortcut.id === noAnsweredAvailableIds.value[0],
-      ) as Shortcut
-    } else {
-      const noAnsweredAvailableShortcuts = state.shortcuts
-        .filter((shortcut) =>
-          noAnsweredAvailableIds.value.includes(shortcut.id),
-        )
-        .filter((shortcut) => shortcut.id !== state.shortcut.id)
-
-      return sample(noAnsweredAvailableShortcuts)
-    }
-  }
-
-  const respondToSelectToolsKey = () => {
-    resetTypingState()
-    state.isListeningKeyboardEvent = false
-    state.isSelectToolsKeyPressed = true
-  }
-
-  const respondToShowCorrectKey = () => {
-    resetTypingState()
-    state.isShowCorrectKeyPressed = true
-  }
-
-  const respondToRemoveKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isRemoveKeyPressed = true
-    state.removedIdSet.add(state.shortcut.id)
-    LocalStorage.set(REMOVED_IDS_KEY, [...state.removedIdSet])
-
-    setTimeout(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
-  }
-
-  const respondToCorrectKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isCorrectKeyPressed = true
-    if (!state.isWrongKeyPressed) saveResult(state.shortcut.id, true)
-
-    setTimeout(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
-  }
-
-  const respondToWrongKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isWrongKeyPressed = true
-    state.isShakingKeyCombinationView = true
-    saveResult(state.shortcut.id, false)
-
-    setTimeout(() => {
-      state.isListeningKeyboardEvent = true
-      state.isShakingKeyCombinationView = false
-      state.pressedKeyCombination.reset()
-    }, TimeIntervalToRestartTyping)
-  }
-
-  const respondToMarkSelfAsCorrectKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isMarkedSelfAsCorrect = true
-    saveResult(state.shortcut.id, true)
-
-    setTimeout(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
-  }
-
-  const respondToMarkSelfAsWrongKey = () => {
-    state.isListeningKeyboardEvent = false
-    state.isMarkedSelfAsWrong = true
-    saveResult(state.shortcut.id, false)
-
-    setTimeout(() => {
-      state.shortcut = nextShortcut()
-      resetTypingState()
-      state.isListeningKeyboardEvent = true
-    }, TimeIntervalToRestartTyping)
-  }
-
-  const saveResult = (id: string, result: boolean) => {
-    if (state.answeredHistoryMap.has(id)) {
-      state.answeredHistoryMap.get(id)?.push(result)
-    } else {
-      state.answeredHistoryMap.set(id, [result])
-    }
-
-    LocalStorage.set(
-      ANSWERED_HISTORY_KEY,
-      Object.fromEntries(state.answeredHistoryMap),
-    )
-  }
-
-  const resetTypingState = () => {
-    state.isRemoveKeyPressed = false
-    state.isCorrectKeyPressed = false
-    state.isWrongKeyPressed = false
-    state.isSelectToolsKeyPressed = false
-    state.isShowCorrectKeyPressed = false
-    state.isMarkedSelfAsCorrect = false
-    state.isMarkedSelfAsWrong = false
-    state.pressedKeyCombination.reset()
-  }
-
-  const restoreRemovedShortcuts = () => {
-    if (
-      confirm(
-        'すべてのショートカットキーが出題されるようになります。\nよろしいですか？',
-      )
-    ) {
-      localStorage.removeItem('removedIds')
-      state.removedIdSet = new Set<string>()
-      resetTypingState()
-      state.shortcut = state.shortcuts[0]
-    }
-  }
-
-  const selectToolAndCategories = (tool: string, categories: string[]) => {
-    state.tool = tool
-    LocalStorage.set(SELECTED_TOOL_KEY, tool)
-
-    state.categories = new Set(categories)
-    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
-
-    state.shortcuts = shortcutStorage.where({
-      tool,
-      categories,
-    })
-
-    state.shortcut =
-      state.shortcuts.find((shortcut) => !removedIds.includes(shortcut.id)) ??
-      state.shortcuts[0]
-
-    exitSelectionOfToolAndCategories()
-  }
-
-  const exitSelectionOfToolAndCategories = () => {
-    resetTypingState()
-    state.isListeningKeyboardEvent = true
-  }
-
-  const masteredRateOfEachTool = (): {
-    name: string
-    masteredRate: number
-  }[] => {
-    const masteredIds = [...state.answeredHistoryMap]
-      .map(([id, results]) => [id, weight(results)] as const)
-      .filter(([, resultWeight]) => resultWeight <= 0.6)
-      .map(([id]) => id)
-
-    const masteredRateOfEachTool: { name: string; masteredRate: number }[] = []
-
-    TOOL_TO_SHORTCUTS_MAP.forEach((shortcuts, name) => {
-      const countOfShortcut = shortcuts.filter(
-        (shortcut) => !state.removedIdSet.has(shortcut.id),
-      ).length
-      const countOfMastered = shortcuts.filter(
-        (shortcut) =>
-          masteredIds.includes(shortcut.id) &&
-          !state.removedIdSet.has(shortcut.id),
-      ).length
-
-      masteredRateOfEachTool.push({
-        name,
-        masteredRate: Math.floor((countOfMastered / countOfShortcut) * 100),
-      })
-    })
-
-    return masteredRateOfEachTool
-  }
-
-  const categoriesWithMasteredRate = (
-    tool: string,
-  ): {
-    name: string
-    masteredRate: number
-  }[] => {
-    const shortcutsOfTool = shortcutStorage.where({ tool })
-    const categoriesOfTool = new Set(
-      shortcutsOfTool.map((shortcut) => shortcut.category),
-    )
-    const masteredIds = [...state.answeredHistoryMap]
-      .map(([id, results]) => [id, weight(results)] as const)
-      .filter(([, resultWeight]) => resultWeight <= 0.6)
-      .map(([id]) => id)
-
-    return Object.values([...categoriesOfTool]).map((categoryName) => {
-      const shortcutsOfCategory = shortcutsOfTool.filter(
-        (shortcut) =>
-          shortcut.category === categoryName &&
-          !state.removedIdSet.has(shortcut.id),
-      )
-      const masteredShortcutsOfCategory = shortcutsOfCategory.filter(
-        (shortcut) => masteredIds.includes(shortcut.id),
-      )
-
-      return {
-        name: categoryName,
-        masteredRate: Math.floor(
-          (masteredShortcutsOfCategory.length / shortcutsOfCategory.length) *
-            100,
-        ),
-      }
-    })
-  }
-
-  const onFullscreenchange = () => {
-    state.isFullscreenMode = !!document.fullscreenElement
-    state.pressedKeyCombination.reset()
-  }
+  const needsFullscreenMode = computed(() => session.needsFullscreenMode())
+  const countsOfEachStatus = computed(() => session.countsOfEachStatus())
 
   return {
     state: readonly(state),
@@ -487,15 +77,15 @@ const gameStore = (shortcuts?: Shortcut[]) => {
     needsFullscreenMode,
     countsOfEachStatus,
 
-    keyDown,
-    keyUp,
-    judge,
-    restoreRemovedShortcuts,
-    selectToolAndCategories,
-    masteredRateOfEachTool,
-    exitSelectionOfToolAndCategories,
-    onFullscreenchange,
-    categoriesWithMasteredRate,
+    keyDown: session.keyDown,
+    keyUp: session.keyUp,
+    judge: session.judge,
+    restoreRemovedShortcuts: session.restoreRemovedShortcuts,
+    selectToolAndCategories: session.selectToolAndCategories,
+    masteredRateOfEachTool: session.masteredRateOfEachTool,
+    exitSelectionOfToolAndCategories: session.exitSelectionOfToolAndCategories,
+    onFullscreenchange: session.onFullscreenchange,
+    categoriesWithMasteredRate: session.categoriesWithMasteredRate,
   }
 }
 

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -10,11 +10,14 @@ import shortcutCatalog from '@/models/shortcut-catalog'
 import {
   createShortcutTrainingSession,
   createShortcutTrainingState,
+  type ShortcutTrainingSessionDeps,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
 import type { Shortcut } from '@/types/interfaces'
 import LocalStorage from '@/utils/local-storage'
 import sample from '@/utils/sample'
+import { weightedSampleKey } from '@/utils/weighted-sample'
+import toggleFullscreen from '@/utils/toggle-fullscreen'
 
 const selectedTool = LocalStorage.get(SELECTED_TOOL_KEY)
 const selectedCategories = LocalStorage.get(SELECTED_CATEGORIES_KEY)
@@ -42,6 +45,28 @@ const createInitialShortcut = (
   return sample(availableShortcuts)
 }
 
+const createTrainingSessionDeps = (): ShortcutTrainingSessionDeps => ({
+  isFullscreenMode: () => !!document.fullscreenElement,
+  sample,
+  weightedSampleKey,
+  scheduleRestartTyping: (callback) => {
+    setTimeout(callback, import.meta.env.MODE === 'test' ? 0 : 1000)
+  },
+  toggleFullscreen,
+  persistAnsweredHistory: (answeredHistory) => {
+    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
+  },
+  persistRemovedIds: (removedIds) => {
+    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
+  },
+  persistSelectedTool: (tool) => {
+    LocalStorage.set(SELECTED_TOOL_KEY, tool)
+  },
+  persistSelectedCategories: (categories) => {
+    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
+  },
+})
+
 const gameStore = (shortcuts?: Shortcut[]) => {
   const state = reactive(
     createShortcutTrainingState({
@@ -51,10 +76,14 @@ const gameStore = (shortcuts?: Shortcut[]) => {
       shortcut: createInitialShortcut(shortcuts, selectedAvailableShortcuts),
       removedIds,
       answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
+      isFullscreenMode: !!document.fullscreenElement,
     }),
-  ) as unknown as ShortcutTrainingState
+  )
 
-  const session = createShortcutTrainingSession(state)
+  const session = createShortcutTrainingSession(
+    state as unknown as ShortcutTrainingState,
+    createTrainingSessionDeps(),
+  )
 
   const removedShortcutExists = computed(() => session.removedShortcutExists())
   const isRemovedAll = computed(() => session.isRemovedAll())

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -5,6 +5,7 @@ import {
   createShortcutTrainingState,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
+import { createShortcutCatalogSummary } from '@/models/shortcut-catalog-summary'
 import {
   createGameSessionBootstrap,
   createGameSessionDeps,
@@ -18,6 +19,7 @@ const gameStore = (shortcuts?: Shortcut[]) => {
   const session = createShortcutTrainingSession(
     state as unknown as ShortcutTrainingState,
     createGameSessionDeps(),
+    createShortcutCatalogSummary(),
   )
 
   const removedShortcutExists = computed(() => session.removedShortcutExists())

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -5,24 +5,11 @@ import {
   createShortcutTrainingState,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
-import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
 import {
   createGameSessionBootstrap,
   createGameSessionDeps,
 } from '@/stores/game-session'
 import type { Shortcut } from '@/types/interfaces'
-
-type TrainingSessionSummarySource = Pick<
-  ShortcutTrainingState,
-  'shortcuts' | 'removedIdSet' | 'answeredHistoryMap'
->
-
-const createTrainingSessionSummary = (state: TrainingSessionSummarySource) =>
-  createShortcutTrainingSessionSummary({
-    shortcuts: state.shortcuts,
-    removedIds: new Set(state.removedIdSet),
-    answeredHistory: new Map(state.answeredHistoryMap),
-  })
 
 const gameStore = (shortcuts?: Shortcut[]) => {
   const bootstrap = createGameSessionBootstrap(shortcuts)
@@ -32,7 +19,6 @@ const gameStore = (shortcuts?: Shortcut[]) => {
     state as unknown as ShortcutTrainingState,
     createGameSessionDeps(),
   )
-  const sessionSummary = computed(() => createTrainingSessionSummary(state))
 
   const removedShortcutExists = computed(() => session.removedShortcutExists())
   const isRemovedAll = computed(() => session.isRemovedAll())
@@ -44,10 +30,8 @@ const gameStore = (shortcuts?: Shortcut[]) => {
   )
   const needsFullscreenMode = computed(() => session.needsFullscreenMode())
   const countsOfEachStatus = computed(() => session.countsOfEachStatus())
-  const masteredRateOfEachTool = () =>
-    sessionSummary.value.masteredRateOfEachTool()
-  const categoriesWithMasteredRate = (tool: string) =>
-    sessionSummary.value.categoriesWithMasteredRate(tool)
+  const masteredRateOfEachTool = session.masteredRateOfEachTool
+  const categoriesWithMasteredRate = session.categoriesWithMasteredRate
 
   return {
     state: readonly(state),

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -18,8 +18,8 @@ const gameStore = (shortcuts?: Shortcut[]) => {
 
   const session = createShortcutTrainingSession(
     state as unknown as ShortcutTrainingState,
-    createGameSessionDeps(),
     createShortcutCatalogSummary(),
+    createGameSessionDeps(),
   )
 
   const removedShortcutExists = computed(() => session.removedShortcutExists())

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -14,7 +14,7 @@ import {
 import { loadGameSessionStorage } from '@/stores/game-session-storage'
 import type { Shortcut } from '@/types/interfaces'
 
-const gameStore = (shortcuts?: Shortcut[]) => {
+const createGameStore = (shortcuts?: Shortcut[]) => {
   const { selectedTool, selectedCategories, removedIds, answeredHistory } =
     loadGameSessionStorage()
   const selectedShortcuts = shortcutCatalog.searchShortcuts({
@@ -32,24 +32,30 @@ const gameStore = (shortcuts?: Shortcut[]) => {
   })
   const state = reactive(createShortcutTrainingState(bootstrap))
 
-  const session = createShortcutTrainingSession(
+  const trainingSession = createShortcutTrainingSession(
     state as unknown as ShortcutTrainingState,
     createShortcutCatalogSummary(),
     createGameSessionDeps(),
   )
 
-  const removedShortcutExists = computed(() => session.removedShortcutExists())
-  const isRemovedAll = computed(() => session.isRemovedAll())
+  const removedShortcutExists = computed(() =>
+    trainingSession.removedShortcutExists(),
+  )
+  const isRemovedAll = computed(() => trainingSession.isRemovedAll())
   const wordsOfDescriptionFilledByCorrectKeys = computed(() =>
-    session.wordsOfDescriptionFilledByCorrectKeys(),
+    trainingSession.wordsOfDescriptionFilledByCorrectKeys(),
   )
   const wordsOfDescriptionFilledByPressedKeys = computed(() =>
-    session.wordsOfDescriptionFilledByPressedKeys(),
+    trainingSession.wordsOfDescriptionFilledByPressedKeys(),
   )
-  const needsFullscreenMode = computed(() => session.needsFullscreenMode())
-  const countsOfEachStatus = computed(() => session.countsOfEachStatus())
-  const masteredRateOfEachTool = session.masteredRateOfEachTool
-  const categoriesWithMasteredRate = session.categoriesWithMasteredRate
+  const needsFullscreenMode = computed(() =>
+    trainingSession.needsFullscreenMode(),
+  )
+  const countsOfEachStatus = computed(() =>
+    trainingSession.countsOfEachStatus(),
+  )
+  const masteredRateOfEachTool = trainingSession.masteredRateOfEachTool
+  const categoriesWithMasteredRate = trainingSession.categoriesWithMasteredRate
 
   return {
     state: readonly(state),
@@ -61,17 +67,18 @@ const gameStore = (shortcuts?: Shortcut[]) => {
     needsFullscreenMode,
     countsOfEachStatus,
 
-    keyDown: session.keyDown,
-    keyUp: session.keyUp,
-    judge: session.judge,
-    restoreRemovedShortcuts: session.restoreRemovedShortcuts,
-    selectToolAndCategories: session.selectToolAndCategories,
+    keyDown: trainingSession.keyDown,
+    keyUp: trainingSession.keyUp,
+    judge: trainingSession.judge,
+    restoreRemovedShortcuts: trainingSession.restoreRemovedShortcuts,
+    selectToolAndCategories: trainingSession.selectToolAndCategories,
     masteredRateOfEachTool,
-    exitSelectionOfToolAndCategories: session.exitSelectionOfToolAndCategories,
-    onFullscreenchange: session.onFullscreenchange,
+    exitSelectionOfToolAndCategories:
+      trainingSession.exitSelectionOfToolAndCategories,
+    onFullscreenchange: trainingSession.onFullscreenchange,
     categoriesWithMasteredRate,
   }
 }
 
-export default gameStore
-export type GameStore = ReturnType<typeof gameStore>
+export default createGameStore
+export type GameStore = ReturnType<typeof createGameStore>

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,12 +1,12 @@
 import { computed, reactive, readonly } from 'vue'
 
+import shortcutCatalog from '@/models/shortcut-catalog'
+import { createShortcutCatalogSummary } from '@/models/shortcut-catalog-summary'
 import {
   createShortcutTrainingSession,
   createShortcutTrainingState,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
-import { createShortcutCatalogSummary } from '@/models/shortcut-catalog-summary'
-import shortcutCatalog from '@/models/shortcut-catalog'
 import {
   createGameSessionBootstrap,
   createGameSessionDeps,
@@ -17,7 +17,7 @@ import type { Shortcut } from '@/types/interfaces'
 const gameStore = (shortcuts?: Shortcut[]) => {
   const { selectedTool, selectedCategories, removedIds, answeredHistory } =
     loadGameSessionStorage()
-  const selectedShortcuts = shortcutCatalog.where({
+  const selectedShortcuts = shortcutCatalog.searchShortcuts({
     tool: selectedTool,
     categories: selectedCategories,
   })

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -6,14 +6,30 @@ import {
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
 import { createShortcutCatalogSummary } from '@/models/shortcut-catalog-summary'
+import shortcutCatalog from '@/models/shortcut-catalog'
 import {
   createGameSessionBootstrap,
   createGameSessionDeps,
 } from '@/stores/game-session'
+import { loadGameSessionStorage } from '@/stores/game-session-storage'
 import type { Shortcut } from '@/types/interfaces'
 
 const gameStore = (shortcuts?: Shortcut[]) => {
-  const bootstrap = createGameSessionBootstrap(shortcuts)
+  const { selectedTool, selectedCategories, removedIds, answeredHistory } =
+    loadGameSessionStorage()
+  const selectedShortcuts = shortcutCatalog.where({
+    tool: selectedTool,
+    categories: selectedCategories,
+  })
+  const bootstrap = createGameSessionBootstrap({
+    tool: selectedTool,
+    categories: selectedCategories,
+    selectedShortcuts,
+    removedIds,
+    answeredHistory,
+    isFullscreenMode: !!document.fullscreenElement,
+    shortcuts,
+  })
   const state = reactive(createShortcutTrainingState(bootstrap))
 
   const session = createShortcutTrainingSession(

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,103 +1,36 @@
 import { computed, reactive, readonly } from 'vue'
 
 import {
-  ANSWERED_HISTORY_KEY,
-  REMOVED_IDS_KEY,
-  SELECTED_CATEGORIES_KEY,
-  SELECTED_TOOL_KEY,
-} from '@/constants/local-storage-keys'
-import shortcutCatalog from '@/models/shortcut-catalog'
-import {
   createShortcutTrainingSession,
   createShortcutTrainingState,
-  type ShortcutTrainingSessionDeps,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
 import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
+import {
+  createGameSessionBootstrap,
+  createGameSessionDeps,
+} from '@/stores/game-session'
 import type { Shortcut } from '@/types/interfaces'
-import LocalStorage from '@/utils/local-storage'
-import sample from '@/utils/sample'
-import { weightedSampleKey } from '@/utils/weighted-sample'
-import toggleFullscreen from '@/utils/toggle-fullscreen'
-
-const selectedTool = LocalStorage.get(SELECTED_TOOL_KEY)
-const selectedCategories = LocalStorage.get(SELECTED_CATEGORIES_KEY)
-const selectedShortcuts = shortcutCatalog.where({
-  tool: selectedTool,
-  categories: selectedCategories,
-})
-
-const removedIds = [...LocalStorage.get(REMOVED_IDS_KEY)]
-
-const selectedAvailableShortcuts = selectedShortcuts.filter(
-  (shortcut) => !removedIds.includes(shortcut.id),
-)
-
-const createInitialShortcut = (
-  shortcuts: Shortcut[] | undefined,
-  selectedShortcuts: Shortcut[],
-) => {
-  const availableShortcuts = shortcuts ?? selectedShortcuts
-
-  if (import.meta.env.MODE === 'test') {
-    return availableShortcuts[0]
-  }
-
-  return sample(availableShortcuts)
-}
-
-const createTrainingSessionDeps = (): ShortcutTrainingSessionDeps => ({
-  isFullscreenMode: () => !!document.fullscreenElement,
-  sample,
-  weightedSampleKey,
-  scheduleRestartTyping: (callback) => {
-    setTimeout(callback, import.meta.env.MODE === 'test' ? 0 : 1000)
-  },
-  toggleFullscreen,
-  persistAnsweredHistory: (answeredHistory) => {
-    LocalStorage.set(ANSWERED_HISTORY_KEY, answeredHistory)
-  },
-  persistRemovedIds: (removedIds) => {
-    LocalStorage.set(REMOVED_IDS_KEY, removedIds)
-  },
-  persistSelectedTool: (tool) => {
-    LocalStorage.set(SELECTED_TOOL_KEY, tool)
-  },
-  persistSelectedCategories: (categories) => {
-    LocalStorage.set(SELECTED_CATEGORIES_KEY, categories)
-  },
-})
 
 type TrainingSessionSummarySource = Pick<
   ShortcutTrainingState,
-  'tool' | 'categories' | 'shortcuts' | 'removedIdSet' | 'answeredHistoryMap'
+  'shortcuts' | 'removedIdSet' | 'answeredHistoryMap'
 >
 
 const createTrainingSessionSummary = (state: TrainingSessionSummarySource) =>
   createShortcutTrainingSessionSummary({
-    tool: state.tool,
-    categories: [...state.categories],
     shortcuts: state.shortcuts,
     removedIds: new Set(state.removedIdSet),
     answeredHistory: new Map(state.answeredHistoryMap),
   })
 
 const gameStore = (shortcuts?: Shortcut[]) => {
-  const state = reactive(
-    createShortcutTrainingState({
-      tool: selectedTool,
-      categories: selectedCategories,
-      shortcuts: shortcuts ?? selectedShortcuts,
-      shortcut: createInitialShortcut(shortcuts, selectedAvailableShortcuts),
-      removedIds,
-      answeredHistory: LocalStorage.get(ANSWERED_HISTORY_KEY),
-      isFullscreenMode: !!document.fullscreenElement,
-    }),
-  )
+  const bootstrap = createGameSessionBootstrap(shortcuts)
+  const state = reactive(createShortcutTrainingState(bootstrap))
 
   const session = createShortcutTrainingSession(
     state as unknown as ShortcutTrainingState,
-    createTrainingSessionDeps(),
+    createGameSessionDeps(),
   )
   const sessionSummary = computed(() => createTrainingSessionSummary(state))
 

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -13,6 +13,7 @@ import {
   type ShortcutTrainingSessionDeps,
   type ShortcutTrainingState,
 } from '@/models/shortcut-training-session'
+import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
 import type { Shortcut } from '@/types/interfaces'
 import LocalStorage from '@/utils/local-storage'
 import sample from '@/utils/sample'
@@ -67,6 +68,20 @@ const createTrainingSessionDeps = (): ShortcutTrainingSessionDeps => ({
   },
 })
 
+type TrainingSessionSummarySource = Pick<
+  ShortcutTrainingState,
+  'tool' | 'categories' | 'shortcuts' | 'removedIdSet' | 'answeredHistoryMap'
+>
+
+const createTrainingSessionSummary = (state: TrainingSessionSummarySource) =>
+  createShortcutTrainingSessionSummary({
+    tool: state.tool,
+    categories: [...state.categories],
+    shortcuts: state.shortcuts,
+    removedIds: new Set(state.removedIdSet),
+    answeredHistory: new Map(state.answeredHistoryMap),
+  })
+
 const gameStore = (shortcuts?: Shortcut[]) => {
   const state = reactive(
     createShortcutTrainingState({
@@ -84,6 +99,7 @@ const gameStore = (shortcuts?: Shortcut[]) => {
     state as unknown as ShortcutTrainingState,
     createTrainingSessionDeps(),
   )
+  const sessionSummary = computed(() => createTrainingSessionSummary(state))
 
   const removedShortcutExists = computed(() => session.removedShortcutExists())
   const isRemovedAll = computed(() => session.isRemovedAll())
@@ -95,6 +111,10 @@ const gameStore = (shortcuts?: Shortcut[]) => {
   )
   const needsFullscreenMode = computed(() => session.needsFullscreenMode())
   const countsOfEachStatus = computed(() => session.countsOfEachStatus())
+  const masteredRateOfEachTool = () =>
+    sessionSummary.value.masteredRateOfEachTool()
+  const categoriesWithMasteredRate = (tool: string) =>
+    sessionSummary.value.categoriesWithMasteredRate(tool)
 
   return {
     state: readonly(state),
@@ -111,10 +131,10 @@ const gameStore = (shortcuts?: Shortcut[]) => {
     judge: session.judge,
     restoreRemovedShortcuts: session.restoreRemovedShortcuts,
     selectToolAndCategories: session.selectToolAndCategories,
-    masteredRateOfEachTool: session.masteredRateOfEachTool,
+    masteredRateOfEachTool,
     exitSelectionOfToolAndCategories: session.exitSelectionOfToolAndCategories,
     onFullscreenchange: session.onFullscreenchange,
-    categoriesWithMasteredRate: session.categoriesWithMasteredRate,
+    categoriesWithMasteredRate,
   }
 }
 

--- a/src/stores/modal-key.ts
+++ b/src/stores/modal-key.ts
@@ -2,5 +2,5 @@ import type { InjectionKey } from 'vue'
 
 import type { ModalStore } from '@/stores/modal'
 
-const ModalKey: InjectionKey<ModalStore> = Symbol('modalStore')
+const ModalKey: InjectionKey<ModalStore> = Symbol('modalStateStore')
 export default ModalKey

--- a/src/stores/modal.ts
+++ b/src/stores/modal.ts
@@ -1,25 +1,25 @@
 import { reactive, readonly } from 'vue'
 
-const modalStore = () => {
+const createModalStore = () => {
   const modalState = reactive({
-    isShowAboutModal: false,
-    isShowToolsAndCategoriesModal: false,
+    isAboutModalVisible: false,
+    isToolsAndCategoriesModalVisible: false,
   })
 
   const showAboutModal = () => {
-    modalState.isShowAboutModal = true
+    modalState.isAboutModalVisible = true
   }
 
   const hideAboutModal = () => {
-    modalState.isShowAboutModal = false
+    modalState.isAboutModalVisible = false
   }
 
   const showToolsAndCategoriesModal = () => {
-    modalState.isShowToolsAndCategoriesModal = true
+    modalState.isToolsAndCategoriesModalVisible = true
   }
 
   const hideToolsAndCategoriesModal = () => {
-    modalState.isShowToolsAndCategoriesModal = false
+    modalState.isToolsAndCategoriesModalVisible = false
   }
 
   return {
@@ -33,5 +33,5 @@ const modalStore = () => {
   }
 }
 
-export default modalStore
-export type ModalStore = ReturnType<typeof modalStore>
+export default createModalStore
+export type ModalStore = ReturnType<typeof createModalStore>

--- a/src/utils/local-storage-core.ts
+++ b/src/utils/local-storage-core.ts
@@ -1,0 +1,60 @@
+import LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE from '@/constants/local-storage-key-to-default-value'
+import { SCHEMA_VERSION_KEY } from '@/constants/local-storage-keys'
+
+export type LocalStorageLike = Pick<
+  Storage,
+  'getItem' | 'setItem' | 'removeItem'
+>
+
+export const LATEST_SCHEMA_VERSION = 0
+
+const readJson = <T>(storage: LocalStorageLike, key: string) => {
+  const json = storage.getItem(key)
+
+  if (!json) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(json) as T
+  } catch {
+    storage.removeItem(key)
+    return undefined
+  }
+}
+
+export const createLocalStorageCore = (storage: LocalStorageLike) => {
+  const isLatestSchemaVersion = () =>
+    readJson<number>(storage, SCHEMA_VERSION_KEY) === LATEST_SCHEMA_VERSION
+
+  const get = (key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE) => {
+    if (key !== SCHEMA_VERSION_KEY && !isLatestSchemaVersion()) {
+      return LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[key]
+    }
+
+    const value = readJson(storage, key)
+    return value ?? LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[key]
+  }
+
+  const set = <T>(
+    key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE,
+    value: T,
+  ) => {
+    storage.setItem(key, JSON.stringify(value))
+
+    if (key !== SCHEMA_VERSION_KEY) {
+      set(SCHEMA_VERSION_KEY, LATEST_SCHEMA_VERSION)
+    }
+  }
+
+  const remove = (key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE) => {
+    storage.removeItem(key)
+  }
+
+  return {
+    get,
+    set,
+    remove,
+    isLatestSchemaVersion,
+  }
+}

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -36,6 +36,10 @@ const LocalStorage = {
       LocalStorage.LATEST_SCHEMA_VERSION
     )
   },
+
+  remove(key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE) {
+    localStorage.removeItem(key)
+  },
 }
 
 export default LocalStorage

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -1,45 +1,5 @@
-import LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE from '@/constants/local-storage-key-to-default-value'
-import { SCHEMA_VERSION_KEY } from '@/constants/local-storage-keys'
+import { createLocalStorageCore } from '@/utils/local-storage-core'
 
-const LocalStorage = {
-  LATEST_SCHEMA_VERSION: 0,
-
-  get(key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE) {
-    if (
-      !localStorage.getItem(key) ||
-      (key !== SCHEMA_VERSION_KEY && !LocalStorage.isLatestSchemaVersion())
-    ) {
-      return LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[key]
-    }
-
-    try {
-      const json = localStorage.getItem(key) as string
-      return JSON.parse(json)
-    } catch {
-      localStorage.removeItem(key)
-      return LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[key]
-    }
-  },
-
-  set<T>(key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE, value: T) {
-    const json = JSON.stringify(value)
-    localStorage.setItem(key, json)
-
-    if (key !== SCHEMA_VERSION_KEY) {
-      LocalStorage.set(SCHEMA_VERSION_KEY, LocalStorage.LATEST_SCHEMA_VERSION)
-    }
-  },
-
-  isLatestSchemaVersion() {
-    return (
-      LocalStorage.get(SCHEMA_VERSION_KEY) ===
-      LocalStorage.LATEST_SCHEMA_VERSION
-    )
-  },
-
-  remove(key: keyof typeof LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE) {
-    localStorage.removeItem(key)
-  },
-}
+const LocalStorage = createLocalStorageCore(localStorage)
 
 export default LocalStorage

--- a/src/utils/weighted-sample.ts
+++ b/src/utils/weighted-sample.ts
@@ -26,11 +26,11 @@ const weightedSampleIndex = (weights: number[]) => {
  * [false] -> 5,
  * [false, false] -> 9
  */
-export function weight(results: boolean[]) {
-  const laterResults = results.slice(-2) // Last 2 results
+export function calculateWeight(results: boolean[]) {
+  const recentResults = results.slice(-2) // Last 2 results
 
   const initialWeight = 1
-  const weight = laterResults.reduce(
+  const weight = recentResults.reduce(
     (previousWeight, result) => previousWeight + (result ? -0.49 : 4),
     initialWeight,
   )

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -10,7 +10,7 @@ import ShortcutsShow from '@/components/ShortcutsShow.vue'
 import ToolsAndCategoriesModal from '@/components/ToolsAndCategoriesModal.vue'
 import useEventListener from '@/composables/use-event-listener'
 import useKeyboardEventListener from '@/composables/use-keyboard-event-listener'
-import gameStore from '@/stores/game'
+import createGameStore from '@/stores/game'
 import GameKey from '@/stores/game-key'
 import {
   NavigatorExtend,
@@ -23,16 +23,14 @@ import lockKeyboard from '@/utils/lock-keyboard'
 const props = withDefaults(
   defineProps<{
     shortcuts?: Shortcut[] | undefined
-    isShowToolModal?: boolean
   }>(),
   {
     shortcuts: undefined,
-    isShowToolModal: false,
   }
 )
 const emit = defineEmits(['hide-modal'])
 
-const game = gameStore(props.shortcuts)
+const game = createGameStore(props.shortcuts)
 provide(GameKey, game)
 const { keyDown, keyUp, isRemovedAll, onFullscreenchange } = game
 
@@ -73,7 +71,6 @@ useKeyboardEventListener('keyup', handleKeyUp)
       <RestoreButton />
     </div>
     <ToolsAndCategoriesModal
-      :is-show="isShowToolModal"
       @hide-modal="emit('hide-modal')"
     />
   </div>

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -28,7 +28,6 @@ const props = withDefaults(
     shortcuts: undefined,
   }
 )
-const emit = defineEmits(['hide-modal'])
 
 const game = createGameStore(props.shortcuts)
 provide(GameKey, game)
@@ -70,9 +69,7 @@ useKeyboardEventListener('keyup', handleKeyUp)
       <ShortcutsShow />
       <RestoreButton />
     </div>
-    <ToolsAndCategoriesModal
-      @hide-modal="emit('hide-modal')"
-    />
+    <ToolsAndCategoriesModal />
   </div>
   <div v-else>
     <span>出題できるショートカットキーがありません。</span>

--- a/test/create-shortcut.test.ts
+++ b/test/create-shortcut.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 
-import { createShortcut } from '@/../data/create-shortcuts'
+import { createShortcut } from '@/../data/create-shortcut'
 import { parseCsv } from '@/../data/parse-csv'
 import chrome from '@/constants/shortcuts/chrome.json'
 import mac from '@/constants/shortcuts/mac.json'

--- a/test/create-shortcuts-core.test.ts
+++ b/test/create-shortcuts-core.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+
+import { createShortcutsFromRecords } from '@/../data/create-shortcuts-core'
+import type { ShortcutDescription } from '@/types/interfaces'
+
+test('create shortcuts from shortcut descriptions in order', () => {
+  const records: ShortcutDescription[] = [
+    {
+      id: '1',
+      app: 'Google Chrome',
+      os: 'macOS',
+      category: 'Tabs',
+      action: 'Move to the last tab',
+      keysDescription: '⌘+9',
+    },
+    {
+      id: '2',
+      app: 'Google Chrome',
+      os: 'macOS',
+      category: 'Tabs',
+      action: 'Minimize window',
+      keysDescription: '⌘+m',
+    },
+  ]
+
+  const shortcuts = createShortcutsFromRecords(records)
+
+  expect(shortcuts.map((shortcut) => shortcut.id)).toEqual(['1', '2'])
+  expect(shortcuts[0]?.isAvailable).toBe(true)
+  expect(shortcuts[1]?.isAvailable).toBe(true)
+})

--- a/test/game-session-storage.test.ts
+++ b/test/game-session-storage.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { getMock, setMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  setMock: vi.fn(),
+}))
+
+vi.mock('@/utils/local-storage', () => ({
+  default: {
+    get: getMock,
+    set: setMock,
+  },
+}))
+
+import {
+  ANSWERED_HISTORY_KEY,
+  REMOVED_IDS_KEY,
+  SELECTED_CATEGORIES_KEY,
+  SELECTED_TOOL_KEY,
+} from '@/constants/local-storage-keys'
+import {
+  createGameSessionStoragePersistence,
+  loadGameSessionStorage,
+} from '@/stores/game-session-storage'
+
+describe('game-session-storage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    setMock.mockReset()
+  })
+
+  test('loads storage values into session-friendly collections', () => {
+    getMock.mockImplementation((key: string) => {
+      if (key === SELECTED_TOOL_KEY) return 'Google Chrome'
+      if (key === SELECTED_CATEGORIES_KEY) return ['Tabs']
+      if (key === REMOVED_IDS_KEY) return ['chrome-1']
+      if (key === ANSWERED_HISTORY_KEY) {
+        return {
+          'chrome-1': [true, false],
+        }
+      }
+
+      return undefined
+    })
+
+    expect(loadGameSessionStorage()).toEqual({
+      selectedTool: 'Google Chrome',
+      selectedCategories: ['Tabs'],
+      removedIds: new Set(['chrome-1']),
+      answeredHistory: new Map([['chrome-1', [true, false]]]),
+    })
+  })
+
+  test('persists session collections back to storage format', () => {
+    const persistence = createGameSessionStoragePersistence()
+
+    persistence.persistRemovedIds(new Set(['chrome-1', 'chrome-2']))
+    persistence.persistAnsweredHistory(
+      new Map([['chrome-1', [true, false]]]),
+    )
+    persistence.persistSelectedTool('Terminal (macOS)')
+    persistence.persistSelectedCategories(['Shell'])
+
+    expect(setMock).toHaveBeenNthCalledWith(1, REMOVED_IDS_KEY, [
+      'chrome-1',
+      'chrome-2',
+    ])
+    expect(setMock).toHaveBeenNthCalledWith(2, ANSWERED_HISTORY_KEY, {
+      'chrome-1': [true, false],
+    })
+    expect(setMock).toHaveBeenNthCalledWith(
+      3,
+      SELECTED_TOOL_KEY,
+      'Terminal (macOS)',
+    )
+    expect(setMock).toHaveBeenNthCalledWith(4, SELECTED_CATEGORIES_KEY, [
+      'Shell',
+    ])
+  })
+})

--- a/test/game-session-storage.test.ts
+++ b/test/game-session-storage.test.ts
@@ -55,9 +55,7 @@ describe('game-session-storage', () => {
     const persistence = createGameSessionStoragePersistence()
 
     persistence.persistRemovedIds(new Set(['chrome-1', 'chrome-2']))
-    persistence.persistAnsweredHistory(
-      new Map([['chrome-1', [true, false]]]),
-    )
+    persistence.persistAnsweredHistory(new Map([['chrome-1', [true, false]]]))
     persistence.persistSelectedTool('Terminal (macOS)')
     persistence.persistSelectedCategories(['Shell'])
 

--- a/test/game-session.test.ts
+++ b/test/game-session.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+import { createGameSessionBootstrap } from '@/stores/game-session'
+
+describe('game-session', () => {
+  test('falls back to an empty shortcut when no shortcuts are available', () => {
+    const bootstrap = createGameSessionBootstrap({
+      tool: 'Google Chrome',
+      categories: ['Tabs'],
+      selectedShortcuts: [],
+      removedIds: new Set(),
+      answeredHistory: new Map(),
+      isFullscreenMode: false,
+    })
+
+    expect(bootstrap.shortcut).toMatchObject({
+      id: '',
+      app: '',
+      category: '',
+      action: '',
+      keyCombinations: [],
+      isAvailable: false,
+    })
+  })
+})

--- a/test/game-view.test.ts
+++ b/test/game-view.test.ts
@@ -1,7 +1,7 @@
 import { nextTick } from 'vue'
 
 import { ANSWERED_HISTORY_KEY } from '@/constants/local-storage-keys'
-import modalStore from '@/stores/modal'
+import createModalStore from '@/stores/modal'
 import ModalKey from '@/stores/modal-key'
 import Keyboard from '@/utils/keyboard'
 import LocalStorage from '@/utils/local-storage'
@@ -122,7 +122,7 @@ const renderGameView = (props: object = { shortcuts: availableShortcuts }) => {
     props,
     global: {
       provide: {
-        [ModalKey as symbol]: modalStore(),
+        [ModalKey as symbol]: createModalStore(),
       },
     },
   })

--- a/test/local-storage-core.test.ts
+++ b/test/local-storage-core.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE from '@/constants/local-storage-key-to-default-value'
+import { ANSWERED_HISTORY_KEY, SCHEMA_VERSION_KEY } from '@/constants/local-storage-keys'
+import {
+  LATEST_SCHEMA_VERSION,
+  createLocalStorageCore,
+  type LocalStorageLike,
+} from '@/utils/local-storage-core'
+
+const createStorage = (): LocalStorageLike & { state: Record<string, string> } => {
+  const state: Record<string, string> = {}
+
+  return {
+    state,
+    getItem: (key: string) => state[key] ?? null,
+    setItem: (key: string, value: string) => {
+      state[key] = value
+    },
+    removeItem: (key: string) => {
+      delete state[key]
+    },
+  }
+}
+
+describe('local-storage-core', () => {
+  let storage: ReturnType<typeof createStorage>
+  let localStorageCore: ReturnType<typeof createLocalStorageCore>
+
+  beforeEach(() => {
+    storage = createStorage()
+    localStorageCore = createLocalStorageCore(storage)
+  })
+
+  test('returns the default value until the schema version is current', () => {
+    storage.setItem(ANSWERED_HISTORY_KEY, JSON.stringify({ foo: [true] }))
+
+    expect(localStorageCore.get(ANSWERED_HISTORY_KEY)).toEqual(
+      LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[ANSWERED_HISTORY_KEY],
+    )
+  })
+
+  test('reads the stored value after the schema version is current', () => {
+    storage.setItem(SCHEMA_VERSION_KEY, JSON.stringify(LATEST_SCHEMA_VERSION))
+    storage.setItem(ANSWERED_HISTORY_KEY, JSON.stringify({ foo: [true] }))
+
+    expect(localStorageCore.get(ANSWERED_HISTORY_KEY)).toEqual({ foo: [true] })
+  })
+
+  test('falls back to the default value when the stored JSON is broken', () => {
+    storage.setItem(SCHEMA_VERSION_KEY, JSON.stringify(LATEST_SCHEMA_VERSION))
+    storage.setItem(ANSWERED_HISTORY_KEY, '{')
+
+    expect(localStorageCore.get(ANSWERED_HISTORY_KEY)).toEqual(
+      LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE[ANSWERED_HISTORY_KEY],
+    )
+    expect(storage.state[ANSWERED_HISTORY_KEY]).toBeUndefined()
+  })
+
+  test('writes the schema version when a non-schema value is saved', () => {
+    localStorageCore.set(ANSWERED_HISTORY_KEY, { foo: [true] })
+
+    expect(storage.getItem(ANSWERED_HISTORY_KEY)).toEqual(
+      JSON.stringify({ foo: [true] }),
+    )
+    expect(storage.getItem(SCHEMA_VERSION_KEY)).toEqual(
+      JSON.stringify(LATEST_SCHEMA_VERSION),
+    )
+  })
+})

--- a/test/local-storage-core.test.ts
+++ b/test/local-storage-core.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, test } from 'vitest'
 
 import LOCAL_STORAGE_KEY_TO_DEFAULT_VALUE from '@/constants/local-storage-key-to-default-value'
-import { ANSWERED_HISTORY_KEY, SCHEMA_VERSION_KEY } from '@/constants/local-storage-keys'
 import {
-  LATEST_SCHEMA_VERSION,
+  ANSWERED_HISTORY_KEY,
+  SCHEMA_VERSION_KEY,
+} from '@/constants/local-storage-keys'
+import {
   createLocalStorageCore,
+  LATEST_SCHEMA_VERSION,
   type LocalStorageLike,
 } from '@/utils/local-storage-core'
 
-const createStorage = (): LocalStorageLike & { state: Record<string, string> } => {
+const createStorage = (): LocalStorageLike & {
+  state: Record<string, string>
+} => {
   const state: Record<string, string> = {}
 
   return {

--- a/test/shortcut-training-session-status.test.ts
+++ b/test/shortcut-training-session-status.test.ts
@@ -37,7 +37,7 @@ describe('shortcut-training-session-status', () => {
         included: 1,
         removed: 1,
       },
-      noAnswered: {
+      unanswered: {
         included: 0,
         removed: 0,
       },

--- a/test/shortcut-training-session-status.test.ts
+++ b/test/shortcut-training-session-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  getAvailableIdToWeightMap,
+  getCountsOfEachStatus,
+  getMasteredIds,
+} from '@/models/shortcut-training-session-status'
+
+const snapshot = {
+  shortcuts: [
+    {
+      id: 'chrome-1',
+    },
+    {
+      id: 'chrome-2',
+    },
+    {
+      id: 'terminal-1',
+    },
+  ] as never,
+  removedIds: new Set(['chrome-2']),
+  answeredHistory: new Map([
+    ['chrome-1', [true]],
+    ['chrome-2', [false]],
+    ['terminal-1', [false, false]],
+  ]),
+}
+
+describe('shortcut-training-session-status', () => {
+  test('counts shortcuts by status', () => {
+    expect(getCountsOfEachStatus(snapshot)).toEqual({
+      mastered: {
+        included: 1,
+        removed: 0,
+      },
+      unmastered: {
+        included: 1,
+        removed: 1,
+      },
+      noAnswered: {
+        included: 0,
+        removed: 0,
+      },
+    })
+  })
+
+  test('returns mastered ids and available weights from the same rule', () => {
+    expect(getMasteredIds(snapshot)).toEqual(['chrome-1'])
+    expect(Array.from(getAvailableIdToWeightMap(snapshot))).toEqual([
+      ['chrome-1', 0.51],
+      ['terminal-1', 9],
+    ])
+  })
+})

--- a/test/shortcut-training-session-summary.test.ts
+++ b/test/shortcut-training-session-summary.test.ts
@@ -1,76 +1,76 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
 
-vi.mock('@/models/shortcut-catalog', () => {
-  const shortcutsByTool = {
-    'Google Chrome': [
-      {
-        id: 'chrome-1',
-        category: 'Tabs',
-      },
-      {
-        id: 'chrome-2',
-        category: 'Tabs',
-      },
-    ],
-    'Terminal (macOS)': [
-      {
-        id: 'terminal-1',
-        category: 'Shell',
-      },
-    ],
-  }
-
-  return {
-    default: {
-      tools: () => Object.keys(shortcutsByTool),
-      where: ({ tool }: { tool: string }) =>
-        (shortcutsByTool[tool as keyof typeof shortcutsByTool] ?? []).map(
-          (shortcut) => ({ ...shortcut }),
-        ),
-      categoriesOf: (tool: string) =>
-        Array.from(
-          new Set(
-            (shortcutsByTool[tool as keyof typeof shortcutsByTool] ?? []).map(
-              (shortcut) => shortcut.category,
-            ),
-          ),
-        ),
+const snapshot = {
+  shortcuts: [
+    {
+      id: 'chrome-1',
     },
-  }
-})
+    {
+      id: 'chrome-2',
+    },
+    {
+      id: 'terminal-1',
+    },
+  ] as never,
+  removedIds: new Set<string>(),
+  answeredHistory: new Map([
+    ['chrome-1', [true]],
+    ['chrome-2', [false]],
+  ]),
+}
 
-const createSnapshot = () =>
-  createShortcutTrainingSessionSummary({
-    shortcuts: [
-      {
-        id: 'chrome-1',
-        category: 'Tabs',
-      },
-      {
-        id: 'chrome-2',
-        category: 'Tabs',
-      },
-      {
-        id: 'terminal-1',
-        category: 'Shell',
-      },
-    ] as never,
-    removedIds: new Set(),
-    answeredHistory: new Map([
-      ['chrome-1', [true]],
-      ['chrome-2', [false]],
-    ]),
-  })
+const catalog = {
+  tools: [
+    {
+      name: 'Google Chrome',
+      shortcuts: [
+        {
+          id: 'chrome-1',
+        },
+        {
+          id: 'chrome-2',
+        },
+      ] as never,
+      categories: [
+        {
+          name: 'Tabs',
+          shortcuts: [
+            {
+              id: 'chrome-1',
+            },
+            {
+              id: 'chrome-2',
+            },
+          ] as never,
+        },
+      ],
+    },
+    {
+      name: 'Terminal (macOS)',
+      shortcuts: [
+        {
+          id: 'terminal-1',
+        },
+      ] as never,
+      categories: [
+        {
+          name: 'Shell',
+          shortcuts: [
+            {
+              id: 'terminal-1',
+            },
+          ] as never,
+        },
+      ],
+    },
+  ],
+}
 
 describe('shortcut-training-session-summary', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   test('shows mastered rate by tool and category', () => {
-    const summary = createSnapshot()
+    const summary = createShortcutTrainingSessionSummary(snapshot, catalog)
 
     expect(summary.masteredRateOfEachTool()).toEqual([
       {

--- a/test/shortcut-training-session-summary.test.ts
+++ b/test/shortcut-training-session-summary.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import createShortcutTrainingSessionSummary from '@/models/shortcut-training-session-summary'
+
+vi.mock('@/models/shortcut-catalog', () => {
+  const shortcutsByTool = {
+    'Google Chrome': [
+      {
+        id: 'chrome-1',
+        category: 'Tabs',
+      },
+      {
+        id: 'chrome-2',
+        category: 'Tabs',
+      },
+    ],
+    'Terminal (macOS)': [
+      {
+        id: 'terminal-1',
+        category: 'Shell',
+      },
+    ],
+  }
+
+  return {
+    default: {
+      tools: () => Object.keys(shortcutsByTool),
+      where: ({ tool }: { tool: string }) =>
+        (shortcutsByTool[tool as keyof typeof shortcutsByTool] ?? []).map(
+          (shortcut) => ({ ...shortcut }),
+        ),
+      categoriesOf: (tool: string) =>
+        Array.from(
+          new Set(
+            (shortcutsByTool[tool as keyof typeof shortcutsByTool] ?? []).map(
+              (shortcut) => shortcut.category,
+            ),
+          ),
+        ),
+    },
+  }
+})
+
+const createSnapshot = () =>
+  createShortcutTrainingSessionSummary({
+    shortcuts: [
+      {
+        id: 'chrome-1',
+        category: 'Tabs',
+      },
+      {
+        id: 'chrome-2',
+        category: 'Tabs',
+      },
+      {
+        id: 'terminal-1',
+        category: 'Shell',
+      },
+    ] as never,
+    removedIds: new Set(),
+    answeredHistory: new Map([
+      ['chrome-1', [true]],
+      ['chrome-2', [false]],
+    ]),
+  })
+
+describe('shortcut-training-session-summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('counts shortcuts by status', () => {
+    const summary = createSnapshot()
+
+    expect(summary.countsOfEachStatus()).toEqual({
+      mastered: {
+        included: 1,
+        removed: 0,
+      },
+      unmastered: {
+        included: 1,
+        removed: 0,
+      },
+      noAnswered: {
+        included: 1,
+        removed: 0,
+      },
+    })
+  })
+
+  test('shows mastered rate by tool and category', () => {
+    const summary = createSnapshot()
+
+    expect(summary.masteredRateOfEachTool()).toEqual([
+      {
+        name: 'Google Chrome',
+        masteredRate: 50,
+      },
+      {
+        name: 'Terminal (macOS)',
+        masteredRate: 0,
+      },
+    ])
+
+    expect(summary.categoriesWithMasteredRate('Google Chrome')).toEqual([
+      {
+        name: 'Tabs',
+        masteredRate: 50,
+      },
+    ])
+  })
+})

--- a/test/shortcut-training-session-summary.test.ts
+++ b/test/shortcut-training-session-summary.test.ts
@@ -69,25 +69,6 @@ describe('shortcut-training-session-summary', () => {
     vi.clearAllMocks()
   })
 
-  test('counts shortcuts by status', () => {
-    const summary = createSnapshot()
-
-    expect(summary.countsOfEachStatus()).toEqual({
-      mastered: {
-        included: 1,
-        removed: 0,
-      },
-      unmastered: {
-        included: 1,
-        removed: 0,
-      },
-      noAnswered: {
-        included: 1,
-        removed: 0,
-      },
-    })
-  })
-
   test('shows mastered rate by tool and category', () => {
     const summary = createSnapshot()
 


### PR DESCRIPTION
## What changed
- Renamed shortcut training session identifiers to match the refactored session model.
- Updated the game, modal, and component wiring to use the new names consistently.
- Adjusted the related tests to reflect the renamed session/status types.

## Why
- The session refactor had completed the structural split, but several identifier names still reflected the old shape.
- This cleanup reduces confusion when navigating the training-session flow and makes the refactor easier to maintain.

## Impact
- No intended behavior change.
- The codebase should be easier to read, and future changes to the shortcut-training flow should be less error-prone.

## Validation
- `npm test`
